### PR TITLE
docs: add AI-DLC workflow handbook

### DIFF
--- a/agents/templates/design.md
+++ b/agents/templates/design.md
@@ -1,14 +1,52 @@
-# Design
+# Design: title
 
-Owner:
+## Identity and links
 
-## User journey
+- Owner:
+- Status: draft
+- Work ID:
+- Requirements:
+- Tracker (when configured):
 
-## States and interactions
-Include errors, loading, empty states, and accessibility.
+## Outcome and scope
 
-## Alternatives and rationale
+- Audience and problem:
+- Measurable outcome:
+- In scope:
+- Non-goals:
+- Constraints:
 
-## Validation
+## User journey and states
 
-## Links
+Describe the entry point, main path, state transitions, permissions, errors,
+loading and empty states, and accessibility needs.
+
+## System boundaries and interfaces
+
+Describe deployment and module boundaries, dependencies, public interfaces,
+data ownership, and failure behavior.
+
+## Decisions and rationale
+
+List alternatives, the selected approach, consequences, and linked ADRs for
+consequential choices.
+
+## Behavioral contract
+
+List acceptance criteria and link the current formal specification when one is
+required. Do not copy provider-owned requirements into this document.
+
+## Verification strategy
+
+Cover applicable acceptance, regression, integration, migration, security, and
+operational evidence.
+
+## Delivery and recovery
+
+Describe implementation slices, compatibility, rollout, observability,
+recovery, and rollback.
+
+## Traceability
+
+Link the work record, specification, ADRs, branch, pull request, and runbooks as
+they become available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ AI-DLC v4 runs as a local Python CLI and library. The MCP facade calls the same 
 
 ## Boundaries
 
-Configuration resolves base, personal, project, and machine scopes with provenance. Portable project data selects role providers and checks; machine data supplies local paths and environment credential references. Workflow services manage reviewed work, immutable provider bindings, operation reconciliation and evidence-gated completion. Check services produce receipts. Provider adapters implement versioned contracts. Renderers generate deterministic client configuration. Copier owns template answers, original revisions and three-way updates.
+Configuration resolves base, personal, project, and machine scopes with provenance. Portable project data selects role providers and checks and may name required credential environment variables; it never contains their values. Machine data supplies account choices and local paths, while the process environment or native sign-in supplies secrets. Workflow services manage reviewed work, immutable provider bindings, operation reconciliation and evidence-gated completion. Check services produce receipts. Provider adapters implement versioned contracts. Renderers generate deterministic client configuration. Copier owns template answers, original revisions and three-way updates.
 
 ## Persistence
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,23 +1,143 @@
-# Development workflow
+# AI-DLC development workflow
 
-Install the pinned runtime and project dependencies through the reviewed bootstrap. Select provider accounts and repository identity explicitly. Keep machine-local paths and environment variables in the machine scope.
+This is the canonical, compact map of the AI-DLC workflow. It describes stable
+development stages and their evidence contracts. Tool names are kept in the
+[tool map](workflows/tool-map.md) so providers can change without redefining the
+lifecycle.
 
-Use the day-start skill to reconcile priorities and evidence. Use discovery for unclear problems, prd-draft for product rationale, needs-spec for the reviewed formal specification decision, and spec-from-prd for approved behavior. Review scope and acceptance criteria before publishing work. Implement on the work branch, run project checks, and finish through the service so merged PR, green CI and current specification evidence are checked. Use day-end and handoff to preserve verified continuity; review-inbox helps triage new requests without automatically publishing them.
+Use the [greenfield guide](workflows/greenfield.md) for a new application and
+the [brownfield guide](workflows/brownfield.md) for an existing repository. The
+[design-to-implementation guide](workflows/design-to-implementation.md) defines
+the handoff between an approved design and code.
 
-## Project adoption
+## Workflow at a glance
 
-`ai-dlc project adopt` previews files; apply only after reviewing conflicts. Existing managed-path files are conflicts, including user-authored configuration or docs. Generic installs no language toolchain. Adoption presets expect existing application manifests and lockfiles, and never create application source. New-project initialization creates a minimal no-dependency language application. Its first setup explicitly creates the lockfile; later setup uses the lock without updating it. Every preset requires the generated-agent-file check; initialized language projects also require a real syntax/compiler check. Extend these baseline checks with acceptance tests as application behavior develops.
+```mermaid
+flowchart TD
+    I[Intake and priority] --> D[Discovery]
+    D --> P[Product requirements]
+    P --> G[Product and technical design]
+    G --> S{Formal specification needed?}
+    S -->|Yes| O[Formal specification]
+    S -->|No| W[Reviewed work record]
+    O --> W
+    W --> B[Branch and implementation]
+    B --> T[Tests and required checks]
+    T --> R[Review and merge]
+    R --> C[Merged-revision CI evidence]
+    C --> F[Evidence-gated finish]
+    F --> H[Tracker completion and handoff]
+```
 
-The Python adoption API accepts `template_source` and `vcs_ref`. For portable updates, use an accessible Git template URL and immutable release tag. Copier creates its own answers recording source/revision. A bundled local template can bootstrap a project, but cannot provide portable updates until distributed as a versioned Git template. Never hand-edit Copier revision history to manufacture upgrade support.
+AI-DLC does not host an autonomous orchestrator. The human and agent decide
+what work is useful. Skills provide judgment; CLI and MCP services validate,
+store, link, reconcile, and gate the resulting work.
 
-Sync copies the checkout into a temporary Git repository and lets Copier perform its update there. Conflicts leave the original untouched. Application files are retained; .git metadata is never copied back. File application uses replacement writes and rollback on ordinary errors; a power-loss-safe multi-file transaction is not claimed.
+## Stage contracts
 
-## CI and release
+| Stage | Purpose | Durable output | Exit condition |
+| --- | --- | --- | --- |
+| Intake | Reconcile an idea with current priorities | Tracker item or reviewed candidate | The next investigation is explicit |
+| Discovery | Establish users, outcomes, constraints, evidence, and unknowns | Bounded problem statement | The problem is clear enough to define or stop |
+| Product requirements | Record rationale, scope, outcomes, risks, and acceptance | Reviewed PRD when the change needs one | Material product questions are resolved or named |
+| Design | Define journeys, states, system boundaries, interfaces, and consequential choices | Design document, diagram, and linked decisions | Implementers can act without inventing product behavior |
+| Specification decision | Decide whether formal behavior needs a specification | Recorded decision and, when required, provider-owned specification | Required scenarios and acceptance criteria are current |
+| Work publication | Bind reviewed scope to durable tracker state | `.ai-dlc/work/<id>.toml` and tracker item | The record is reviewed before external mutation |
+| Implementation | Deliver the smallest coherent change on the bound branch | Code, tests, migrations, and updated durable docs | Local required checks pass |
+| Review and merge | Evaluate correctness, maintainability, risk, and scope | Reviewed pull request and merged revision | Required review and repository rules pass |
+| Verification and finish | Authenticate the merge and its configured evidence | CI receipts and optional deployment evidence | `ai-dlc work finish <work-id>` accepts every configured gate |
+| Continuity | Preserve only what the next person or session needs | Handoff, runbook updates, and linked personal notes | Remote state and remaining work are unambiguous |
 
-The generated single-job `.github/workflows/verify.yml` runs reviewed bootstrap artifacts and required checks, then uploads its `ai-dlc-receipt` artifact. Repositories with a matrix, including AI-DLC itself, declare every exact expected artifact name in `scm.receipt_artifacts`. Completion reads that declaration from the authenticated merged revision and validates every expected receipt; one missing, malformed, dirty, mismatched, or expired receipt blocks completion. Until a signed/pinned release location exists, supply bootstrap/release.sh and the artifact lock from the published distribution; do not insert a made-up release URL. The release gate must check clean-machine bootstrap and artifact integrity.
+Each stage consumes reviewed output from the previous stage. Skipping an
+artifact is acceptable when the stage explicitly decides it is unnecessary;
+silently replacing it with assumptions is not.
 
-Skill release requires no-guidance control and skill-enabled model runs using agents/evaluation.toml and scenarios. Preserve outputs and human scoring. The fixture configuration alone is not a passing behavioral evaluation.
+## Sources of truth
 
-Adoption accepts selected role capabilities (specs, tracker, knowledge, scm, deploy, agent-client); omitted selection enables all defaults. Selection is recorded by Copier and controls provider-role configuration; the GitHub workflow is omitted without SCM. Shared repository docs and bootstrap remain available. Rebind accepts optional machine configuration for validating existing bindings but never writes machine data into the project configuration.
+- The repository owns architecture, product rationale, design context,
+  decisions, runbooks, code, and tests.
+- The configured specification provider exclusively owns formal behavior
+  specifications. Repository design documents link to specifications instead
+  of copying them.
+- The tracker owns priority and lifecycle status.
+- SCM and CI own review, merge identity, and merged-revision evidence.
+- Personal knowledge stores continuity, reflection, and private notes. It links
+  durable repository material and is not a repository mirror.
+- Portable configuration may name required environment variables, such as
+  `token_env = "LINEAR_API_KEY"`, but never contains their secret values.
+  Machine configuration, the process environment, and `.ai-dlc/local/` own
+  actual credential values, account choices, local paths, caches, and operation
+  journals.
 
-Snapshot and staging skip .git, language dependency folders, common tool caches, .ai-dlc/local, and Git-ignored untracked paths. These runtime files remain untouched in the destination. A checkout edit detected after staging aborts application and asks for a fresh preview/retry.
+When sources disagree, reconcile their owned facts rather than overwriting one
+store with a copy from another.
+
+## Capability boundaries
+
+Initialization and adoption may select any subset of `specs`, `tracker`,
+`knowledge`, `scm`, `deploy`, and `agent-client`. Selection controls declared
+roles and generated provider assets. The runtime retains compatibility
+fallbacks for local OpenSpec and GitHub, but a fallback does not choose an
+account, repository, or authorization and must not be mistaken for a configured
+role. GitHub uses conventional `verify.yml` and `main` defaults unless they are
+overridden. The tracker has no fallback.
+
+- Project setup, checks, architecture, design, decisions, and runbooks remain
+  useful without external providers.
+- The full publish/start/status/finish lifecycle requires configured tracker and
+  SCM roles. Without either role, use the local project lifecycle and manual
+  tracking, or configure the missing role before publishing work.
+- Without a declared specification role, work may deliberately use the local
+  OpenSpec compatibility fallback when its formal artifacts exist. Otherwise,
+  work that does not require a specification records `requires_spec = false`
+  with a reviewed reason; work that does require one configures the role.
+- Knowledge, deployment evidence, and agent clients are optional. Their stages
+  are omitted when their roles are not selected; deployment becomes a finish
+  gate only when configured.
+- Omitting SCM also omits the generated GitHub workflow. Local required checks
+  still run, but merged-revision CI completion is unavailable.
+
+## Daily operating loop
+
+1. Reconcile tracker priority, work bindings, branch state, and fresh evidence.
+2. Use discovery when the problem or outcome is unclear.
+3. Draft and review product requirements when durable rationale is needed.
+4. Produce the minimum design that closes product and technical ambiguity.
+5. Record whether formal specification is required and make it current when it
+   is.
+6. Review the work record, then publish and start it through AI-DLC.
+7. Implement on the bound branch with acceptance and regression tests.
+8. Run `ai-dlc project check --required` before review.
+9. Merge through the configured SCM and finish through AI-DLC so current
+   specification, merged revision, CI receipts, and deployment evidence are
+   checked together.
+10. Update durable documentation and leave a concise handoff when continuity is
+    needed.
+
+## Completion is evidence-gated
+
+`ai-dlc work finish <work-id>` is the completion boundary for projects with the
+required tracker and SCM capabilities. It checks the authenticated merged
+revision rather than the local checkout. The generated single-job GitHub
+workflow publishes `ai-dlc-receipt`; matrix repositories declare every exact
+expected artifact in `scm.receipt_artifacts`. A missing, malformed, dirty,
+mismatched, duplicate, or expired receipt blocks completion.
+
+Tracker completion never substitutes for a merge, green CI, a current required
+specification, or configured deployment evidence. Failures remain visible and
+retryable instead of being converted into success.
+
+## Maintaining this handbook
+
+- Keep lifecycle stages and role names provider-neutral.
+- Update [the tool map](workflows/tool-map.md) when a configured provider,
+  command, or skill changes.
+- Update the greenfield or brownfield guide when initialization or adoption
+  behavior changes.
+- Update the design handoff when required design evidence changes.
+- Store diagrams as Mermaid beside the text they explain. Exported images are
+  optional views, never the editable source.
+- Change the handbook, project template, relevant skills, and behavior in the
+  same pull request when they form one contract.
+- Use Git history for evolution; do not maintain a parallel changelog inside
+  every guide.

--- a/docs/workflows/brownfield.md
+++ b/docs/workflows/brownfield.md
@@ -1,0 +1,114 @@
+# Brownfield workflow
+
+Use this path when bringing AI-DLC into an existing repository or changing an
+existing product. Adoption must preserve application files and observed
+behavior while introducing portable workflow controls deliberately.
+
+[Back to the workflow map](../development-workflow.md)
+
+## Flow
+
+```mermaid
+flowchart TD
+    I[Inventory repository] --> P[Preview adoption]
+    P --> A[Apply reviewed files]
+    A --> C[Characterize current behavior]
+    C --> D[Design incremental change]
+    D --> S[Specification decision]
+    S --> W[Publish and start work]
+    W --> M[Implement and migrate]
+    M --> V[Regression checks, review, merge, finish]
+```
+
+## 1. Inventory before adopting
+
+Identify the deployable application, manifests and lockfiles, module and data
+boundaries, public interfaces, CI rules, operational runbooks, and existing
+documentation. Record unknown behavior instead of guessing. Find owner-written
+files that overlap AI-DLC managed paths before applying a template.
+
+Establish a clean test baseline. Where important behavior lacks tests, add
+characterization tests that describe the current observable contract before
+changing it. A characterization test is evidence, not an endorsement of the
+current design.
+
+## 2. Preview and apply adoption
+
+Preview first:
+
+```sh
+ai-dlc project adopt --root /path/to/project --preset generic
+```
+
+Review every proposed file and conflict, then repeat with `--apply`. Existing
+managed-path files are conflicts, including user-authored configuration and
+documentation. Adoption presets expect existing manifests and lockfiles and do
+not create application source. The generic preset installs no language
+toolchain.
+
+The bundled template can bootstrap a checkout, but portable updates require an
+accessible Git template URL and immutable release tag. Copier owns its answers,
+source, revision, and three-way update history; never hand-edit that history to
+manufacture upgrade support.
+
+## 3. Establish the managed boundary
+
+After adoption, distinguish four areas:
+
+- application code and owner-authored documents that AI-DLC must preserve;
+- template-managed workflow files that can receive reviewed updates;
+- provider-owned remote state such as specifications, tracker status, and SCM
+  evidence;
+- machine-local state such as credentials, paths, caches, and journals.
+
+Snapshot and staging omit `.git`, dependency directories, tool caches,
+`.ai-dlc/local/`, and Git-ignored untracked files. Runtime files remain
+untouched. If the checkout changes after staging, application aborts and asks
+for a fresh preview instead of applying a stale plan. Copier conflicts leave
+the original checkout untouched.
+
+## 4. Design the incremental change
+
+Begin from the current journey and interfaces, not the desired implementation.
+State what must remain compatible, what may migrate, and how users or dependent
+systems cross the transition. Include data migration, rollout, observability,
+recovery, and rollback when the change can affect stored or remote state.
+
+Follow the [design-to-implementation contract](design-to-implementation.md).
+For a risky change, prefer multiple independently releasable slices over a
+single replacement. Record consequential compatibility decisions in an ADR.
+
+## 5. Specify, publish, and implement
+
+Decide whether changed behavior requires a formal specification. Use the
+configured provider or a deliberately used local OpenSpec compatibility
+fallback when one is required; otherwise record `requires_spec = false` and its
+reviewed reason. With tracker and SCM capabilities configured, link the design
+and specification from the work record, then publish and start through AI-DLC.
+Otherwise, use the local project lifecycle and manual tracking. Implement on
+the bound branch when available and preserve unrelated repository behavior.
+Add regression tests for old contracts and acceptance tests for new outcomes.
+
+For template updates, run a preview before applying. Sync stages the checkout
+in a temporary Git repository and asks Copier to perform the three-way update.
+Application files are retained, `.git` metadata is never copied back, ordinary
+write errors roll back, and conflicts leave the destination untouched. A
+power-loss-safe multi-file transaction is not claimed.
+
+## 6. Review, migrate, and finish
+
+Review compatibility evidence, migrations, rollback, documentation, and the
+new behavior—not only the code diff. Always run required checks locally. With
+tracker and SCM roles configured, merge through SCM, observe rollout evidence
+when configured, and use `ai-dlc work finish <work-id>` to authenticate the
+merged revision before completing remote tracker state. Otherwise, close the
+manual lifecycle without claiming AI-DLC remote completion.
+
+## Ready and done
+
+Brownfield work is ready when current behavior, compatibility boundaries,
+affected owners, incremental design, specification decision, rollback needs,
+and test strategy are explicit. Local work is done when required old and new
+behavior is verified and migrations and runbooks are current. With tracker and
+SCM roles configured, done additionally means the reviewed PR is merged and
+AI-DLC accepts every finish gate.

--- a/docs/workflows/design-to-implementation.md
+++ b/docs/workflows/design-to-implementation.md
@@ -1,0 +1,102 @@
+# Design to implementation
+
+This guide defines the evidence passed from product and technical design into
+implementation. A design explains intent, journeys, constraints, boundaries,
+and decisions. It does not duplicate a PRD, formal specification, tracker, or
+implementation diff.
+
+[Back to the workflow map](../development-workflow.md)
+
+## The handoff contract
+
+An implementation-ready design answers the following questions or links to the
+artifact that does:
+
+| Area | Required evidence |
+| --- | --- |
+| Identity | Work ID, title, owner, status, and links to tracker and requirements |
+| Outcome | Audience, problem, measurable outcome, scope, and explicit non-goals |
+| Journey | Entry point, main path, state transitions, permissions, errors, empty/loading states, and accessibility needs |
+| System | Deployment and module boundaries, dependency direction, interfaces, data ownership, and failure behavior |
+| Decisions | Alternatives considered, selected approach, consequences, and linked ADRs for consequential choices |
+| Behavior | Acceptance criteria and links to the current formal specification when required |
+| Verification | Acceptance, regression, integration, migration, security, and operational test strategy as applicable |
+| Delivery | Incremental slices, compatibility constraints, rollout, observability, recovery, and rollback |
+| Traceability | Work record, specification, decisions, branch, pull request, and runbook links as they become available |
+
+The source templates live at `agents/templates/design.md`,
+`agents/templates/adr.md`, and `agents/templates/runbook.md`; generated projects
+receive them under `docs/templates/`. Update `docs/architecture.md` only when
+the durable system view changes.
+
+## Handoff flow
+
+```mermaid
+flowchart TD
+    R[Reviewed requirements] --> D[Design document]
+    D --> A[Architecture and ADR updates]
+    A --> N{Material behavior needs formal specification?}
+    N -->|Yes| S[Current formal specification and scenarios]
+    N -->|No| E[Recorded no-spec decision]
+    S --> W[Reviewed AI-DLC work record]
+    E --> W
+    W --> P[Implementation slices and test plan]
+    P --> B[Bound work branch]
+    B --> PR[Code, tests, docs, pull request]
+```
+
+
+The work record is the traceability bridge. It binds approved scope and remote
+artifacts before implementation mutates the tracker or creates branch state.
+It should link durable sources rather than paste their contents.
+
+## Greenfield handoff
+
+For a new application, design begins with the first deployable boundary and
+one end-to-end user outcome. Define the minimum architecture needed for that
+slice, then identify which interfaces are intentionally stable and which are
+still internal. Avoid designing hypothetical services, extension systems, or
+configuration until a requirement needs them.
+
+The first slice must leave a reproducible setup, lockfile, baseline checks, and
+one observable behavior. Its tests prove both the language/toolchain baseline
+and the user outcome.
+
+## Brownfield handoff
+
+For an existing application, design begins with evidence about current
+behavior. List affected interfaces, callers, data, operational procedures, and
+compatibility promises. Characterization tests protect important existing
+contracts. The design states how each slice moves from the current state to the
+target state and how to recover if the transition fails.
+
+Do not use a broad rewrite as the handoff unit when an incremental change can
+be reviewed, verified, and rolled back independently.
+
+## Implementation expectations
+
+Before coding, an implementer should be able to map each acceptance criterion
+or required scenario to a planned slice and verification method. During
+implementation:
+
+- work only on the bound branch and within reviewed scope;
+- use tests to drive new behavior and reproduce bugs;
+- preserve unrelated user changes and existing contracts;
+- update design, decisions, architecture, and runbooks when code invalidates
+  them;
+- make uncertainty visible instead of inventing product behavior;
+- run required project checks before review.
+
+The pull request should explain the outcome, design decisions, compatibility
+or migration effects, and evidence. Review compares implementation with the
+linked design and specification. `ai-dlc work finish <work-id>` then verifies
+the merged revision and remote evidence; it does not infer success from the
+local branch.
+
+## Change control
+
+If implementation reveals a material product, interface, security, migration,
+or operational decision that the design does not answer, pause and update the
+reviewed artifact before continuing. Small implementation details may remain
+in code and tests. Decisions that future maintainers must understand belong in
+the repository.

--- a/docs/workflows/greenfield.md
+++ b/docs/workflows/greenfield.md
@@ -1,0 +1,111 @@
+# Greenfield workflow
+
+Use this path when creating a new deployable application rather than adopting
+an existing repository. The goal is a small, working vertical slice with clear
+ownership and repeatable checks—not a speculative platform.
+
+[Back to the workflow map](../development-workflow.md)
+
+## Flow
+
+```mermaid
+flowchart TD
+    A[Select capabilities] --> I[Initialize project]
+    I --> B[Bootstrap and verify tools]
+    B --> F[Define product and architecture foundation]
+    F --> D[Design first vertical slice]
+    D --> S[Specification decision]
+    S --> W[Publish and start work]
+    W --> V[Implement vertical slice]
+    V --> C[Check, review, merge, finish]
+```
+
+## 1. Select the project boundary and capabilities
+
+Start with one deployable application and explicit module responsibilities.
+Split deployment only when requirements justify independent operational
+ownership. Select only the provider roles the project needs: specification,
+tracker, knowledge, SCM, deployment evidence, and agent clients.
+
+Record the initial runtime, storage, external dependencies, public interfaces,
+and operational owner in `docs/architecture.md`. Portable configuration may
+name required environment variables, but machine scope and the process
+environment own account selection, machine-specific paths, and actual secret
+values.
+
+## 2. Initialize and bootstrap
+
+Create the project with the relevant language preset:
+
+```sh
+ai-dlc project init my-project --preset python --apply
+```
+
+Generic, Python/uv, Node, and Rust presets include durable documentation and
+shared agent instructions. Initialized language projects contain a minimal
+dependency-free application. First setup creates the language lockfile; later
+setup uses that lock without updating it. Every preset checks generated agent
+files, and initialized language projects also run a real syntax or compiler
+check.
+
+Run the reviewed bootstrap, then:
+
+```sh
+ai-dlc project setup
+ai-dlc project check --required
+```
+
+Do not add feature work until the empty project can be recreated and its
+baseline checks pass.
+
+## 3. Establish product and design context
+
+Define the audience, problem, measurable outcome, exclusions, constraints, and
+owner. A PRD is useful when those decisions must survive beyond the work item.
+Create the smallest design that covers the first user journey, including empty,
+loading, error, permission, and accessibility states where relevant.
+
+Document consequential architecture choices under `docs/decisions/`. Link
+decisions from the design rather than repeating their rationale. Follow the
+[design-to-implementation contract](design-to-implementation.md) before coding.
+
+## 4. Decide on formal specification
+
+Use the specification decision skill after requirements and design are
+reviewed. When formal behavior is required, translate approved outcomes and
+scenarios through the configured specification provider or a deliberately used
+local OpenSpec compatibility fallback. When no specification is required,
+record `requires_spec = false` and its reviewed reason. The specification is
+authoritative for behavior; the design remains authoritative for rationale and
+interaction context.
+
+## 5. Publish, start, and implement
+
+When tracker and SCM capabilities are configured, prepare and review
+`.ai-dlc/work/<id>.toml`, then publish it. Publication creates or reuses the
+tracker item. Starting the work binds its branch and transitions the remote
+lifecycle state. Without both roles, continue with local project checks and a
+manual lifecycle until the missing role is configured.
+
+Implement the smallest end-to-end slice that demonstrates the outcome. Add
+acceptance tests and extend `checks.required` as real application behavior is
+introduced. Keep architecture, design, decisions, migrations, and runbooks in
+the same change when the code makes them stale.
+
+## 6. Review, merge, and finish
+
+Always run required checks locally and review the change against the design and
+any required formal specification. When tracker and SCM roles are configured,
+merge through SCM and use `ai-dlc work finish <work-id>`; it authenticates the
+merged revision and validates configured CI and deployment evidence before
+completing the tracker item. Otherwise, close the project's manual lifecycle
+without claiming AI-DLC remote completion.
+
+## Ready and done
+
+The first implementation is ready when its user, outcome, scope, design,
+specification decision, and test strategy are explicit; a work record is also
+required for the configured remote lifecycle. Local work is done when the
+vertical slice works, required checks pass, and durable documents match the
+implementation. With tracker and SCM roles configured, done additionally means
+the reviewed PR is merged and AI-DLC accepts the finish gates.

--- a/docs/workflows/tool-map.md
+++ b/docs/workflows/tool-map.md
@@ -1,0 +1,134 @@
+# Workflow tool map
+
+The lifecycle uses stable roles; `ai-dlc.toml` selects their current providers.
+This page records how the default AI-DLC toolset participates without making a
+vendor part of the lifecycle definition.
+
+[Back to the workflow map](../development-workflow.md)
+
+## Role to provider mapping
+
+| Stable responsibility | AI-DLC role or service | Current default | Owns |
+| --- | --- | --- | --- |
+| Formal behavior | `specs` | OpenSpec | Requirements and scenarios |
+| Priority and lifecycle | `tracker` | Linear | Work identity, priority, and status |
+| Personal continuity | `knowledge` | Obsidian | Private notes, reflection, and links |
+| Review, merge, and CI identity | `scm` | GitHub | Branches, pull requests, merged SHA, workflow runs, and artifacts |
+| Deployment evidence | `deploy` | None by default | Environment-specific release evidence when configured |
+| Interactive agent | `agent-client` | Claude Code and Codex | Analysis, judgment, authoring, and tool use under user authorization |
+| Deterministic workflow | AI-DLC CLI/MCP services | Local Python implementation | Validation, rendering, bindings, reconciliation, receipts, and gates |
+| Project generation and updates | Template service | Copier | Template answers, source revision, preview, and three-way updates |
+
+Projects may omit roles they do not need. Confirm the actual mapping in the
+project's `ai-dlc.toml`; do not infer an account, workspace, repository, or
+environment from these defaults.
+
+The complete evidence-gated work cycle currently requires configured tracker
+and SCM roles. The runtime retains compatibility fallbacks for local OpenSpec
+and GitHub, but they do not choose account, repository, or authorization.
+GitHub uses conventional `verify.yml` and `main` defaults unless overridden;
+the tracker has no fallback. Without a configured tracker or SCM role, project
+initialization, adoption, setup, checks, design, and documentation remain
+available, but publish/start/status/finish is not a usable end-to-end lifecycle.
+A missing specification role may deliberately use local OpenSpec when its
+artifacts exist; otherwise the work must be reviewed with
+`requires_spec = false`. Knowledge, deployment, and agent clients remain
+optional.
+
+## Skill map
+
+| Moment | Skill | Expected judgment output |
+| --- | --- | --- |
+| Start of work | `day-start` | Reconciled priority, bindings, branch, and evidence |
+| Unclear problem | `discovery` | Bounded problem, evidence, assumptions, questions, and next investigation |
+| Durable product rationale | `prd-draft` | Reviewed problem, outcomes, scope, constraints, risks, and acceptance |
+| Specification decision | `needs-spec` | Explicit decision based on behavior and risk |
+| Approved behavior | `spec-from-prd` | Provider-owned requirements and scenarios linked to rationale |
+| Incoming idea or note | `review-inbox` | Classification and next action without automatic publication |
+| Session or ownership transfer | `handoff` | Verified state, decisions, evidence, risks, and next action |
+| End of work period | `day-end` | Concise continuity record and reconciled remote state |
+
+Skills provide judgment patterns. Provider instructions define vendor
+operations. AI-DLC services own validation and mutation boundaries. A skill
+cannot bypass completion gates or expand the user's authorization.
+
+## Command and service map
+
+| Area | Interfaces | Effect |
+| --- | --- | --- |
+| Readiness and context | `ai-dlc doctor`, `ai-dlc context` | Checks the selected environment and summarizes work/check context |
+| Project creation | `ai-dlc project init`, `ai-dlc project adopt` | Initializes a project or previews/applies conflict-safe adoption |
+| Project maintenance | `ai-dlc project sync`, `ai-dlc project rebind` | Performs staged Copier updates or previews/applies reviewed provider rebinding |
+| Project execution | `ai-dlc project setup`, `ai-dlc project check --required` | Runs declared setup and checks and emits verification receipts |
+| Agent configuration | `ai-dlc agents render` | Previews, applies, or verifies owned project/personal client configuration |
+| Work lifecycle | `ai-dlc work publish`, `ai-dlc work start`, `ai-dlc work status`, `ai-dlc work finish` | Reconciles tracker state, binds work to a branch, and enforces completion gates |
+| Traceability | `ai-dlc work link` | Links PR, specification, branch, deployment, or tracker evidence to reviewed work |
+| Provider inspection | `ai-dlc provider list`, `ai-dlc provider test` | Discovers adapters and runs isolated contract or authorized live checks |
+| Personal knowledge | `ai-dlc knowledge find`, `ai-dlc knowledge note`, `ai-dlc knowledge append` | Reads or writes explicitly selected vault material |
+| Configuration profiles | `ai-dlc profile show`, `ai-dlc profile migrate`, `ai-dlc profile capture` | Resolves provenance, previews schema migration, or captures supported preferences |
+| Machine provisioning | `ai-dlc setup plan`, `ai-dlc setup apply` | Previews or applies selected workstation modules and personal agent configuration |
+| Agent-native access | `ai-dlc mcp serve` | Exposes the same workflow services and validation through local MCP |
+| Legacy compatibility | `ai-dlc scaffold` | Preserves the retired Rust-era provider scaffolding interface |
+
+## Artifact ownership
+
+```mermaid
+flowchart TD
+    H[Human and agent judgment] --> R[Repository rationale and design]
+    H --> SP[Specification provider]
+    H --> TR[Tracker]
+    H --> PK[Personal knowledge]
+    R --> WR[AI-DLC work record]
+    SP --> WR
+    TR --> WR
+    WR --> SCM[Branch, PR, merge, and CI]
+    SCM --> FIN[AI-DLC finish gates]
+    SP --> FIN
+    FIN --> TR
+```
+
+- Repository: architecture, PRDs, design context, ADRs, runbooks, code, tests.
+- Specification provider: formal behavior and scenarios.
+- Tracker: priority, work identity, lifecycle state.
+- SCM/CI: review, merge identity, test artifacts, and receipts.
+- Knowledge provider: private continuity and links to durable artifacts.
+- Portable project configuration: provider roles and names of required
+  environment variables, never their values.
+- Local machine scope and process environment: actual credential values,
+  account choices, paths, caches, and operation journals.
+
+## CI and release evidence
+
+The generated GitHub workflow runs reviewed bootstrap artifacts and required
+checks, then uploads a receipt. Single-job projects use `ai-dlc-receipt`.
+Matrix repositories list every exact expected artifact in
+`scm.receipt_artifacts`; finish reads this declaration from the authenticated
+merged revision and validates every receipt.
+
+Until a signed and pinned AI-DLC release exists, projects must supply the
+published `bootstrap/release.sh` and corresponding artifact manifest instead
+of inventing an unpinned download URL. Release gates must cover clean-machine
+bootstrap and artifact integrity.
+
+Skill publication has a separate behavioral gate: run no-guidance control and
+skill-enabled scenarios from `agents/evaluation.toml`, preserve transcripts,
+and record human scoring. Packaging a skill is not evidence that it changes
+agent behavior correctly.
+
+## Evolving the toolset
+
+When replacing or adding a tool:
+
+1. Keep the lifecycle stage and responsibility stable where possible.
+2. Update `ai-dlc.toml`, provider contracts, and machine credential references.
+3. Describe the new provider here and remove claims that no longer apply.
+4. Update relevant skills only when the judgment pattern changes.
+5. Rebind existing work through reviewed mappings; provider changes apply to
+   new work by default.
+6. Add deterministic contract and integration tests plus an explicit live
+   walkthrough for externally mutating providers.
+7. Update diagrams and project templates in the same reviewed change.
+
+Never place secret values, account identifiers, or machine-local paths in this
+map. Naming a required environment variable in portable configuration is safe;
+storing its value there is not.

--- a/playbook/README.md
+++ b/playbook/README.md
@@ -2,6 +2,8 @@
 
 AI-DLC is a local CLI/library plus project templates and agent skills. It does not host orchestration. The human and agent decide what work is useful; deterministic services validate, store, and link that work.
 
+Use the [development workflow handbook](../docs/development-workflow.md) for the compact lifecycle, greenfield and brownfield paths, design handoff, diagrams, and current tool map.
+
 Start with one deployable application and explicit module boundaries. Split deployment only when requirements justify it. Repository maintainers own architecture, product rationale, design context, decisions, and runbooks. Update these documents alongside relevant code.
 
 The specification role is the sole formal behavior specification system. The tracker owns priority and lifecycle status. Personal knowledge holds continuity, reflection, and private notes; it links durable repository material. Do not mirror all four stores or resolve contradictory state by overwriting it.

--- a/project-templates/project/AI-DLC.md
+++ b/project-templates/project/AI-DLC.md
@@ -2,6 +2,8 @@
 
 The repository owns durable architecture, product rationale, decisions, and runbooks. The specification role owns formal behavior specifications. The tracker owns priority and lifecycle status. Personal knowledge notes remain personal and link durable repository material.
 
+Start with the [Development workflow](docs/development-workflow.md). It links the greenfield and brownfield paths, the design-to-implementation contract, and the current role-to-tool map.
+
 Select scm.repository and provider account/environment references before external operations. Every preset checks generated agent files. New-project initialization also creates a minimal language app and requires its syntax/compiler check; first setup creates its lockfile and later setup is locked. Adoption leaves existing application manifests/source untouched and requires existing language lockfiles. Add acceptance tests and further required check IDs as behavior develops.
 
 This development template needs the AI-DLC release bootstrap artifacts before CI can run. The template includes reviewed scripts/bootstrap.sh and bootstrap prerequisite pins; supply bootstrap/release.sh and the corresponding locked artifact manifest from a published AI-DLC release. Verify the release integrity; do not download an unpinned latest script. No public release location is assumed.

--- a/project-templates/project/docs/development-workflow.md.jinja
+++ b/project-templates/project/docs/development-workflow.md.jinja
@@ -1,0 +1,88 @@
+# AI-DLC development workflow
+
+This is the project entry point for the AI-DLC lifecycle. It describes stable
+stages; the [tool map](workflows/tool-map.md) shows which configured provider or
+service currently performs each role.
+
+- [Greenfield development](workflows/greenfield.md)
+- [Brownfield development](workflows/brownfield.md)
+- [Design to implementation](workflows/design-to-implementation.md)
+- [Tools, skills, services, and artifact ownership](workflows/tool-map.md)
+
+```mermaid
+flowchart TD
+    I[Intake] --> D[Discovery]
+    D --> P[Requirements]
+    P --> G[Design]
+    G --> S[Specification decision]
+    S --> W[Reviewed work record]
+    W --> B[Branch and implementation]
+    B --> T[Tests and checks]
+    T --> R[Review and merge]
+    R --> F[Evidence-gated finish]
+    F --> H[Tracker completion and handoff]
+```
+
+## Stage contract
+
+| Stage | Durable output | Exit condition |
+| --- | --- | --- |
+| Intake and discovery | Bounded problem, evidence, assumptions, and next investigation | The problem is clear enough to define or stop |
+| Requirements | Reviewed outcomes, scope, constraints, risks, and acceptance | Material product questions are resolved or named |
+| Design | Journey, states, system boundaries, decisions, and verification strategy | Implementation does not need to invent product behavior |
+| Specification decision | Recorded decision and provider-owned specification when required | Required scenarios are current |
+| Publish and start | `.ai-dlc/work/<id>.toml`, tracker item, and bound branch | Reviewed scope is linked before implementation |
+| Implement and verify | Code, tests, migrations, and current durable docs | Required local checks pass |
+| Review, merge, and finish | Reviewed PR, merged SHA, CI receipts, and deployment evidence when configured | `ai-dlc work finish <work-id>` accepts every finish gate |
+| Continuity | Handoff, runbook updates, and linked personal notes | Remote state and next action are unambiguous |
+
+## Sources of truth
+
+- This repository owns architecture, rationale, design, decisions, runbooks,
+  code, and tests.
+- The specification provider owns formal behavior and scenarios.
+- The tracker owns priority and lifecycle status.
+- SCM and CI own review, merge identity, and merged-revision evidence.
+- Personal knowledge owns private continuity and links; it is not a repository
+  mirror.
+- Portable configuration may name required environment variables but never
+  contains their secret values. Machine scope and the process environment own
+  actual credentials, account choices, paths, caches, and local journals.
+
+## Capability boundaries
+
+This handbook ships for every capability selection. This project was generated
+with:
+
+- `specs`: {{ "configured" if "specs" in capabilities else "not configured" }}
+- `tracker`: {{ "configured" if "tracker" in capabilities else "not configured" }}
+- `knowledge`: {{ "configured" if "knowledge" in capabilities else "not configured" }}
+- `scm`: {{ "configured" if "scm" in capabilities else "not configured" }}
+- `deploy`: {{ "configured" if "deploy" in capabilities else "not configured" }}
+- `agent-client`: {{ "configured" if "agent-client" in capabilities else "not configured" }}
+
+Capability selection controls declared roles and generated provider assets. The
+runtime retains compatibility fallbacks for local OpenSpec and GitHub, but a
+fallback does not choose an account, repository, or authorization and must not
+be mistaken for a configured role. GitHub uses conventional `verify.yml` and
+`main` defaults unless overridden. The tracker has no fallback.
+
+Apply these boundaries:
+
+- Project setup, checks, architecture, design, decisions, and runbooks work
+  without external providers.
+- The complete publish/start/status/finish lifecycle requires configured
+  tracker and SCM roles. Without both, use local checks and manual tracking, or
+  configure the missing role before publishing work.
+- Without a declared specification role, work may deliberately use the local
+  OpenSpec compatibility fallback when its artifacts exist. Otherwise, work
+  must record `requires_spec = false` with a reviewed reason or configure the
+  role.
+- Knowledge, deployment evidence, and agent clients are optional; omit their
+  stages when the corresponding role is not selected.
+- Omitting SCM also omits the generated GitHub workflow and makes
+  merged-revision CI completion unavailable.
+
+Keep stages provider-neutral. When a tool changes, update `ai-dlc.toml` and the
+tool map rather than redefining the lifecycle. Keep Mermaid beside the text it
+explains so diagrams and decisions evolve in the same pull request.

--- a/project-templates/project/docs/templates/design.md
+++ b/project-templates/project/docs/templates/design.md
@@ -1,14 +1,52 @@
-# Design
+# Design: title
 
-Owner:
+## Identity and links
 
-## User journey
+- Owner:
+- Status: draft
+- Work ID:
+- Requirements:
+- Tracker (when configured):
 
-## States and interactions
-Include errors, loading, empty states, and accessibility.
+## Outcome and scope
 
-## Alternatives and rationale
+- Audience and problem:
+- Measurable outcome:
+- In scope:
+- Non-goals:
+- Constraints:
 
-## Validation
+## User journey and states
 
-## Links
+Describe the entry point, main path, state transitions, permissions, errors,
+loading and empty states, and accessibility needs.
+
+## System boundaries and interfaces
+
+Describe deployment and module boundaries, dependencies, public interfaces,
+data ownership, and failure behavior.
+
+## Decisions and rationale
+
+List alternatives, the selected approach, consequences, and linked ADRs for
+consequential choices.
+
+## Behavioral contract
+
+List acceptance criteria and link the current formal specification when one is
+required. Do not copy provider-owned requirements into this document.
+
+## Verification strategy
+
+Cover applicable acceptance, regression, integration, migration, security, and
+operational evidence.
+
+## Delivery and recovery
+
+Describe implementation slices, compatibility, rollout, observability,
+recovery, and rollback.
+
+## Traceability
+
+Link the work record, specification, ADRs, branch, pull request, and runbooks as
+they become available.

--- a/project-templates/project/docs/workflows/brownfield.md
+++ b/project-templates/project/docs/workflows/brownfield.md
@@ -1,0 +1,48 @@
+# Brownfield workflow
+
+Use this path when adopting AI-DLC into an existing repository or changing an
+existing product. Preserve application files and observed behavior while
+introducing workflow controls deliberately.
+
+[Back to the workflow map](../development-workflow.md)
+
+```mermaid
+flowchart TD
+    I[Inventory] --> P[Preview adoption]
+    P --> A[Apply reviewed files]
+    A --> C[Characterize current behavior]
+    C --> D[Design incremental change]
+    D --> S[Specify, publish, start]
+    S --> M[Implement and migrate]
+    M --> V[Regression checks, review, merge, finish]
+```
+
+1. Inventory manifests, lockfiles, boundaries, interfaces, CI, runbooks,
+   existing documentation, and owner-written files on managed paths.
+2. Establish a clean baseline and add characterization tests for important
+   behavior that is not already protected.
+3. Preview with `ai-dlc project adopt --root /path/to/project --preset generic`.
+   Apply only after reviewing every proposed file and conflict. Adoption never
+   creates application source for an existing project.
+4. Separate application-owned, template-managed, provider-owned, and
+   machine-local state. Keep credentials and caches out of portable files.
+5. Design the incremental transition from current behavior. State compatibility,
+   migration, rollout, observability, recovery, and rollback requirements.
+6. Record the specification decision. Use the configured provider or local
+   OpenSpec compatibility fallback when formal behavior is required; otherwise
+   record `requires_spec = false` and its reviewed reason.
+7. With tracker and SCM configured, publish and start reviewed work, merge
+   through SCM, and use `ai-dlc work finish <work-id>` after review. Otherwise,
+   use local checks and manual tracking without claiming AI-DLC remote
+   completion. In either path, protect the change with regression and
+   acceptance tests.
+
+Copier updates use a staged three-way merge. Conflicts or a concurrently changed
+checkout leave the destination untouched and require a fresh preview. Runtime,
+Git, dependency, ignored, and `.ai-dlc/local/` files are not copied through the
+staging area.
+
+Local work is done when required old and new behavior is verified and
+migrations and runbooks are current. With tracker and SCM configured, done
+additionally means the reviewed PR is merged and AI-DLC accepts every finish
+gate.

--- a/project-templates/project/docs/workflows/design-to-implementation.md
+++ b/project-templates/project/docs/workflows/design-to-implementation.md
@@ -1,0 +1,48 @@
+# Design to implementation
+
+A design explains intent, journeys, constraints, system boundaries, and
+decisions. It links to requirements and formal specifications without copying
+them. Implementation is ready when the following evidence is present or
+explicitly judged unnecessary.
+
+[Back to the workflow map](../development-workflow.md)
+
+| Area | Evidence |
+| --- | --- |
+| Identity | Work ID, title, owner, status, tracker, and requirements links |
+| Outcome | Audience, problem, measurable outcome, scope, and non-goals |
+| Journey | Entry point, main path, states, permissions, errors, empty/loading states, and accessibility |
+| System | Deployment and module boundaries, interfaces, data ownership, dependencies, and failure behavior |
+| Decisions | Alternatives, selected approach, consequences, and linked ADRs |
+| Behavior | Acceptance criteria and current formal specification when required |
+| Verification | Acceptance, regression, integration, migration, security, and operational tests as applicable |
+| Delivery | Incremental slices, compatibility, rollout, observability, recovery, and rollback |
+| Traceability | Work record, decisions, specification, branch, PR, and runbooks |
+
+```mermaid
+flowchart TD
+    R[Reviewed requirements] --> D[Design]
+    D --> A[Architecture and decisions]
+    A --> N{Formal behavior specification?}
+    N -->|Yes| S[Current scenarios]
+    N -->|No| E[Recorded decision]
+    S --> W[Reviewed work record]
+    E --> W
+    W --> P[Implementation slices and tests]
+    P --> B[Bound branch]
+    B --> PR[Code, docs, review, and evidence]
+```
+
+For greenfield work, center the handoff on one deployable boundary and vertical
+slice. For brownfield work, begin with current behavior, callers, data,
+compatibility promises, characterization tests, and an incremental transition.
+
+If implementation uncovers a material product, interface, security, migration,
+or operational choice that the design does not answer, pause and update the
+reviewed artifact. Small implementation details may remain in code and tests;
+decisions future maintainers need belong in repository documentation.
+
+For projects with tracker and SCM roles, link the reviewed design to the work
+record before publication and use `ai-dlc work finish <work-id>` after merge.
+Without those roles, keep the same design evidence and test discipline but use
+the project's manual lifecycle until the roles are configured.

--- a/project-templates/project/docs/workflows/greenfield.md
+++ b/project-templates/project/docs/workflows/greenfield.md
@@ -1,0 +1,47 @@
+# Greenfield workflow
+
+Use this path for a new deployable application. Start with one application and
+one end-to-end user outcome; split deployment only when requirements justify
+independent operational ownership.
+
+[Back to the workflow map](../development-workflow.md)
+
+```mermaid
+flowchart TD
+    I[Initialize] --> B[Bootstrap]
+    B --> F[Product and architecture foundation]
+    F --> D[Design first vertical slice]
+    D --> S[Specification decision]
+    S --> W[Publish and start]
+    W --> V[Implement vertical slice]
+    V --> C[Check, review, merge, finish]
+```
+
+1. Select only the needed provider roles and initialize with the relevant
+   preset, for example `ai-dlc project init my-project --preset python --apply`.
+2. Run project setup and required checks. Initialized language presets create a
+   minimal application and real syntax/compiler check; first setup creates the
+   lockfile and later setup remains locked.
+3. Record audience, outcome, exclusions, ownership, deployment boundary,
+   modules, dependencies, interfaces, and operational assumptions.
+4. Design the first vertical slice, including error, empty, loading,
+   permission, and accessibility states where relevant.
+5. Record the formal specification decision. Make required scenarios current
+   through the configured provider or a deliberately used local OpenSpec
+   compatibility fallback; otherwise record `requires_spec = false` and its
+   reviewed reason.
+6. With tracker and SCM configured, review the work record, then publish and
+   start it through AI-DLC. Otherwise use local checks and manual tracking until
+   those roles are configured.
+7. Implement the smallest coherent slice, add acceptance tests, and extend
+   required checks as behavior grows.
+8. Always run required local checks. With tracker and SCM configured, review
+   and merge through SCM and use `ai-dlc work finish <work-id>` to validate the
+   merged revision before tracker completion. Otherwise close the manual
+   lifecycle without claiming AI-DLC remote completion.
+
+The slice is ready when its user, outcome, design, specification decision, and
+test strategy are explicit; configured remote work also requires a reviewed
+work record. Local work is done when code and durable documents agree and
+required checks pass. With tracker and SCM configured, done additionally means
+the PR is merged and finish gates accept the remote evidence.

--- a/project-templates/project/docs/workflows/tool-map.md
+++ b/project-templates/project/docs/workflows/tool-map.md
@@ -1,0 +1,71 @@
+# Workflow tool map
+
+AI-DLC defines stable responsibilities and maps them to providers through
+`ai-dlc.toml`. Confirm this project's selected roles; omitted capabilities are
+not configured provider choices.
+
+[Back to the workflow map](../development-workflow.md)
+
+| Responsibility | Role or service | Default provider | Durable ownership |
+| --- | --- | --- | --- |
+| Formal behavior | `specs` | OpenSpec | Requirements and scenarios |
+| Priority and lifecycle | `tracker` | Linear | Work identity, priority, and status |
+| Personal continuity | `knowledge` | Obsidian | Private notes, reflection, and links |
+| Review and merge | `scm` | GitHub | Branch, PR, merged SHA, CI runs, and artifacts |
+| Deployment evidence | `deploy` | None | Environment evidence when configured |
+| Interactive agent | `agent-client` | Claude Code and Codex | Analysis, authoring, and authorized tool use |
+| Workflow enforcement | AI-DLC CLI/MCP | Local services | Validation, bindings, reconciliation, receipts, and gates |
+| Project lifecycle | Copier | Template service | Answers, source revision, preview, and three-way updates |
+
+The complete publish/start/status/finish lifecycle requires configured tracker
+and SCM roles. Local OpenSpec and GitHub compatibility fallbacks exist, but do
+not select account, repository, or authorization. GitHub uses conventional
+`verify.yml` and `main` defaults unless overridden; the tracker has no fallback.
+Without tracker or SCM configuration, initialization, adoption, setup, checks,
+design, and documentation remain available, but evidence-gated remote
+completion does not. A missing specification role may deliberately use the
+local OpenSpec fallback when its artifacts exist; otherwise work must be
+reviewed with `requires_spec = false`. Knowledge, deployment, and agent clients
+are optional.
+
+## Skills by stage
+
+| Stage | Skill |
+| --- | --- |
+| Reconcile current state | `day-start` |
+| Clarify an uncertain problem | `discovery` |
+| Preserve product rationale | `prd-draft` |
+| Decide on formal behavior | `needs-spec` |
+| Translate approved behavior | `spec-from-prd` |
+| Triage incoming ideas | `review-inbox` |
+| Transfer verified context | `handoff` |
+| Close a work period | `day-end` |
+
+Skills provide judgment. Provider instructions define vendor operations.
+AI-DLC services own validation and mutation boundaries; no skill bypasses finish
+gates or extends user authorization.
+
+## Command groups
+
+| Area | Interfaces |
+| --- | --- |
+| Readiness and context | `ai-dlc doctor`, `ai-dlc context` |
+| Project lifecycle | `ai-dlc project init`, `ai-dlc project adopt`, `ai-dlc project sync`, `ai-dlc project setup`, `ai-dlc project check --required`, `ai-dlc project rebind` |
+| Agent configuration | `ai-dlc agents render` |
+| Work and traceability | `ai-dlc work publish`, `ai-dlc work link`, `ai-dlc work start`, `ai-dlc work status`, `ai-dlc work finish` |
+| Provider verification | `ai-dlc provider list`, `ai-dlc provider test` |
+| Personal knowledge | `ai-dlc knowledge find`, `ai-dlc knowledge note`, `ai-dlc knowledge append` |
+| Profiles and machine setup | `ai-dlc profile show`, `ai-dlc profile migrate`, `ai-dlc profile capture`; `ai-dlc setup plan`, `ai-dlc setup apply` |
+| Agent-native access | `ai-dlc mcp serve` |
+| Legacy compatibility | `ai-dlc scaffold` |
+
+The local MCP server calls the same services and validation as the CLI. The
+legacy scaffold command preserves the retired Rust-era provider interface; it
+is not the project lifecycle.
+
+When replacing a tool, keep its responsibility stable where possible. Update
+configuration, provider contracts, this map, relevant skills, integration
+tests, live walkthrough evidence, and project templates together. Rebind
+existing work explicitly; do not silently move it between providers. Portable
+configuration may name environment variables, but actual secrets, account
+choices, and machine-local paths remain outside portable project files.

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -86,6 +86,57 @@ def test_presets(tmp_path, preset):
     assert not list((root / ".ai-dlc/work").glob("*.toml"))
 
 
+@pytest.mark.parametrize("capabilities", [None, ["specs", "scm"], []])
+def test_project_template_includes_workflow_handbook(tmp_path, capabilities):
+    root = tmp_path / "project"
+
+    assert adopt(root, apply=True, capabilities=capabilities)["status"] == "applied"
+
+    expected = {
+        "docs/development-workflow.md",
+        "docs/workflows/brownfield.md",
+        "docs/workflows/design-to-implementation.md",
+        "docs/workflows/greenfield.md",
+        "docs/workflows/tool-map.md",
+    }
+    generated = {path.relative_to(root).as_posix() for path in root.rglob("*.md")}
+    assert expected <= generated
+    handbook = (root / "docs/development-workflow.md").read_text()
+    assert (
+        "[Development workflow](docs/development-workflow.md)" in (root / "AI-DLC.md").read_text()
+    )
+    selected = (
+        {
+            "specs",
+            "tracker",
+            "knowledge",
+            "scm",
+            "deploy",
+            "agent-client",
+        }
+        if capabilities is None
+        else set(capabilities)
+    )
+    for role in ["specs", "tracker", "knowledge", "scm", "deploy", "agent-client"]:
+        state = "configured" if role in selected else "not configured"
+        assert f"- `{role}`: {state}" in handbook
+    design_headings = {
+        line
+        for line in (root / "docs/templates/design.md").read_text().splitlines()
+        if line.startswith("## ")
+    }
+    assert {
+        "## Identity and links",
+        "## Outcome and scope",
+        "## User journey and states",
+        "## System boundaries and interfaces",
+        "## Decisions and rationale",
+        "## Behavioral contract",
+        "## Verification strategy",
+        "## Delivery and recovery",
+    } <= design_headings
+
+
 def test_initialized_python_check_does_not_dirty_repository(tmp_path):
     from ai_dlc.project import check_project, setup_project
 


### PR DESCRIPTION
## Motivation

Give AI-DLC one durable, version-controlled home for its evolving lifecycle, current tools, skills, evidence boundaries, and design-to-implementation guidance.

## Changes

- expand the canonical development workflow with stage contracts, source-of-truth rules, capability boundaries, and Mermaid diagrams
- add detailed greenfield, brownfield, design-to-implementation, and tool-map guides
- align the reusable design template with the documented handoff contract
- ship a compact, capability-aware handbook in newly initialized or adopted projects
- document all user-facing CLI command groups and compatibility fallback behavior
- add template regression coverage across full, reduced, and empty capability selections

## Verification

- ai-dlc project check --required
- 180 tests passed
- generated-file, formatting, lint, and type checks passed
- generated handbook links and code fences validated
- independent review found no Critical or Important issues and marked the result ready to merge

## Notes

This is documentation and template guidance only; it does not change provider runtime compatibility behavior.