### PR TITLE
feat: add portable profile enrollment lifecycle

### DIFF
--- a/.ai-dlc/work/portable-profile-enrollment.toml
+++ b/.ai-dlc/work/portable-profile-enrollment.toml
@@ -1,0 +1,25 @@
+schema = 1
+id = "portable-profile-enrollment"
+title = "Implement portable profile and machine enrollment"
+scope = "Enroll a secret-free personal profile from an exact Git revision, bind it per machine, and safely resolve, reconcile, synchronize, inspect, and diagnose it."
+requires_spec = true
+spec_reason = "Changes configuration ownership, credential references, machine state, CLI behavior, and synchronization guarantees."
+acceptance = [
+  "Two isolated machines resolve one pinned profile with distinct local bindings",
+  "Preview, apply, sync, status, and doctor preserve active state on failure",
+  "Credentials remain external and no secret value is persisted or returned",
+  "Existing schema-4 and setup/profile/doctor interfaces remain compatible",
+  "Required project checks and independent review pass",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/archive/2026-09-03-portable-profile-enrollment"
+branch = "codex/portable-profile-enrollment"

--- a/README.md
+++ b/README.md
@@ -19,11 +19,52 @@ After adding those directories:
 ```sh
 ai-dlc project check --required
 ai-dlc doctor
-ai-dlc setup plan --profile profiles/sean.toml
-ai-dlc setup apply --profile profiles/sean.toml
+ai-dlc setup plan --profile profiles/example/ai-dlc-profile.toml
+ai-dlc setup apply --profile profiles/example/ai-dlc-profile.toml
 ```
 
 Machine setup installs the selected workstation modules. Interactive sign-ins and provider workspace selections remain explicit. Configure Linear's team and native status IDs before publishing work. Keep vault paths and account choices in a machine TOML file, and supply it with `--machine` where supported. Credentials are environment references or native tool sign-ins.
+
+## Portable profile and machine enrollment
+
+Keep a personal `ai-dlc-profile.toml` in a separate private Git repository. It
+contains portable module choices, logical credential requirements, and optional
+agent configuration, but no account selection, path, repository, vault, or
+credential value. Enroll a reviewed, pinned Git revision on the first machine,
+then enroll that same pinned revision on a second machine with its own machine
+ID and binding. Each machine edits its local binding independently.
+
+Preview enrollment can materialize an inactive cache, but does not change the
+active enrollment, client configuration, or package state. Repeat the same
+command with `--apply` to activate it:
+
+```sh
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG --apply
+```
+
+The local lock always records the exact resolved commit. Choose one of two
+policies: an immutable advertised tag or ref gives cross-machine reproducibility
+and makes `ai-dlc machine sync` idempotent; an intentionally movable advertised
+branch lets `ai-dlc machine sync` preview a newer candidate and `ai-dlc machine
+sync --apply` activate it after validation and reconciliation. To move from one
+immutable tag to another, reenroll with the new ref. Enroll a second machine
+with the same advertised ref under the selected policy and its own machine ID.
+
+Use `ai-dlc machine status`, `plan`, `apply`, `sync`, and `doctor` to inspect,
+preview, reconcile, update, and diagnose that enrollment. Put Linear and future
+provider credentials in a password manager or keychain that injects the
+configured environment variable (for example, `LINEAR_SANDBOX_TOKEN`); never
+put values in AI-DLC Git files or commit `.env` files.
+
+Local CLI and local MCP execution are the current control plane. Hosted or
+cloud execution is a later qualification target, not a feature claim. Obsidian
+create/attach and provider discovery are also next-cycle gaps; current knowledge
+commands act only on an explicitly selected existing vault.
+
+MCP exposes reviewed work operations, read-only doctor inspection, and selected
+knowledge operations. Machine enrollment mutations remain CLI-only in this
+cycle.
 
 Personal MCP servers declared in the selected profile are previewed by `setup plan` and merged into the supported user-level Codex and Claude configuration during `setup apply`. AI-DLC records only the entries it owns, preserves unrelated settings, and stops on edited or colliding entries. To review or apply only this layer, use `ai-dlc agents render --personal <profile> --check` and then replace `--check` with `--apply`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,40 @@
 # Architecture
 
-AI-DLC v4 runs as a local Python CLI and library. The MCP facade calls the same services. Project adoption uses Copier; provider adapters isolate vendor-specific operations; agent skills provide judgment. There is no hosted orchestration service.
+AI-DLC v4 runs as a local Python CLI and library. The CLI owns machine
+enrollment mutation; the MCP facade exposes only reviewed work, doctor, and
+knowledge services. Project adoption uses Copier; provider adapters isolate
+vendor-specific operations; agent skills provide judgment. There is no hosted
+orchestration service.
 
 ## Boundaries
 
-Configuration resolves base, personal, project, and machine scopes with provenance. Portable project data selects role providers and checks and may name required credential environment variables; it never contains their values. Machine data supplies account choices and local paths, while the process environment or native sign-in supplies secrets. Workflow services manage reviewed work, immutable provider bindings, operation reconciliation and evidence-gated completion. Check services produce receipts. Provider adapters implement versioned contracts. Renderers generate deterministic client configuration. Copier owns template answers, original revisions and three-way updates.
+Configuration resolves five ownership layers with provenance:
+
+1. A private Git profile owns portable modules, MCP preferences, workflow
+   choices, and logical credential requirements. Pin an exact revision before
+   enrolling it on every machine.
+2. The project repository owns shared project configuration, policy, durable
+   architecture, decisions, and runbooks.
+3. Each machine binding owns local paths, account selections, and mappings from
+   logical credentials to environment-variable names.
+4. A password manager, keychain, or process environment owns credential values.
+   AI-DLC never records, prints, or synchronizes those values.
+5. Codex and Claude user/project configuration owns generated client files;
+   AI-DLC re-renders only entries it owns.
+
+Enrollment locks, profile caches, and operation journals are local control
+state, not portable authority. The profile is synchronized by its private Git
+repository; the project is synchronized by its repository; machine bindings,
+credential stores, and local journals stay on their respective machines.
+
+Portable project data selects role providers and checks and may name required
+credential environment variables; it never contains their values. Machine data
+supplies account choices and local paths, while the process environment or
+native sign-in supplies secrets. Workflow services manage reviewed work,
+immutable provider bindings, operation reconciliation and evidence-gated
+completion. Check services produce receipts. Provider adapters implement
+versioned contracts. Renderers generate deterministic client configuration.
+Copier owns template answers, original revisions and three-way updates.
 
 ## Persistence
 
@@ -12,4 +42,8 @@ The repository stores architecture, design rationale, decisions, runbooks and re
 
 ## Deployment and interfaces
 
-Prefer one application with explicit module responsibilities over speculative service decomposition. CLI, MCP and agent clients share the same services and validation rules. External provider failures and uncertain mutations remain visible. Credentials are environment references, never template values.
+Prefer one application with explicit module responsibilities over speculative service decomposition. CLI, MCP, and agent clients share validation where an MCP service is exposed; the CLI alone owns machine enrollment mutation. The local CLI and local MCP are today's primary control plane; hosted or cloud execution is a later qualification target. External provider failures and uncertain mutations remain visible. Credentials are environment references, never template values.
+
+Knowledge ownership stays provider-neutral: private knowledge links durable
+repository material but does not mirror it. Obsidian create/attach and provider
+discovery are next-cycle capabilities, not implemented behavior.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -30,8 +30,9 @@ flowchart TD
 ```
 
 AI-DLC does not host an autonomous orchestrator. The human and agent decide
-what work is useful. Skills provide judgment; CLI and MCP services validate,
-store, link, reconcile, and gate the resulting work.
+what work is useful. Skills provide judgment; the CLI validates, stores, links,
+reconciles, and gates the resulting work. MCP exposes only its reviewed work,
+doctor, and knowledge services.
 
 ## Stage contracts
 
@@ -52,6 +53,53 @@ Each stage consumes reviewed output from the previous stage. Skipping an
 artifact is acceptable when the stage explicitly decides it is unnecessary;
 silently replacing it with assumptions is not.
 
+## Design to implementation ownership
+
+For both greenfield and brownfield work, skills own discovery, requirements,
+design judgment, and the specification decision. The CLI owns reviewed work
+records, local checks, machine lifecycle commands, and completion gates. Local
+MCP exposes reviewed work operations, read-only doctor inspection, and selected
+knowledge operations; machine enrollment mutations are CLI-only in this cycle.
+It does not create a second workflow. The design-to-implementation handoff is complete only when the
+approved design, any required specification, and the reviewed work record let
+implementation proceed without inventing behavior.
+
+## Portable profile and machine enrollment
+
+Keep a personal `ai-dlc-profile.toml` in a separate private Git repository and
+pin the revision enrolled on each machine. The profile owns portable modules,
+logical credential requirements, and agent preferences; the project repository
+owns shared policy and durable docs. Each machine independently owns its
+binding, including paths, account selection, and environment-variable names.
+Credential values belong only to a password manager, keychain, or process
+environment. Generated Codex and Claude client files remain owned by their
+client configuration, which AI-DLC updates through its ownership rules.
+
+Use `ai-dlc machine status`, `plan`, `apply`, `sync`, and `doctor` to inspect,
+preview, reconcile, update, and diagnose local enrollment. Local CLI and MCP
+execution are the current control plane; hosted or cloud execution is a later
+qualification target. Obsidian create/attach and provider discovery are
+next-cycle gaps, so knowledge remains provider-neutral and is attached only to
+an explicitly selected existing store.
+
+Preview a private profile enrollment can materialize an inactive cache, but it
+does not change active enrollment, client configuration, or package state.
+Repeat the same command with `--apply` to activate it:
+
+```sh
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG --apply
+```
+
+The lock always records the exact resolved commit. An immutable advertised tag
+or ref gives cross-machine reproducibility, and `ai-dlc machine sync` is
+idempotent for it. An intentionally movable advertised branch instead enables
+`ai-dlc machine sync` to preview a candidate and `ai-dlc machine sync --apply`
+to activate it after validation and reconciliation. To move from one immutable
+tag to another, reenroll with the new ref. Enroll a second machine with the
+same advertised ref under the selected policy and a different machine ID; its
+local binding remains independent.
+
 ## Sources of truth
 
 - The repository owns architecture, product rationale, design context,
@@ -65,9 +113,10 @@ silently replacing it with assumptions is not.
   durable repository material and is not a repository mirror.
 - Portable configuration may name required environment variables, such as
   `token_env = "LINEAR_API_KEY"`, but never contains their secret values.
-  Machine configuration, the process environment, and `.ai-dlc/local/` own
-  actual credential values, account choices, local paths, caches, and operation
-  journals.
+  Machine configuration owns account choices and local paths. `.ai-dlc/local/`
+  may hold ignored non-secret control-plane IDs and local metadata. Actual
+  credential values stay in an OS keychain, password manager, or secret
+  injector and enter only the process environment.
 
 When sources disagree, reconcile their owned facts rather than overwriting one
 store with a copy from another.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,10 +4,42 @@ Inventory existing aliases, shell functions, PATH entries and installed ai-dlc/a
 
 Schema 4 separates portable project configuration from machine bindings. Review old provider selections and credentials; migrate secret values to environment variables. Select scm.repository explicitly. Machine-specific vault paths and account settings belong in machine configuration. Do not copy local journals as a substitute for remote state reconciliation.
 
+For a personal profile such as `profiles/sean.toml`, create a separate private
+profile repository and move the portable choices into its canonical
+`ai-dlc-profile.toml`. Preview legacy enrollment, then repeat with `--apply`:
+
+```sh
+ai-dlc machine migrate SOURCE --profile-file profiles/sean.toml --profile-id legacy-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG
+ai-dlc machine migrate SOURCE --profile-file profiles/sean.toml --profile-id legacy-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG --apply
+```
+
+The legacy preview can materialize an inactive cache, but does not change active
+enrollment, client configuration, or package state. Its lock pins the resolved
+commit when applied. After moving to the canonical filename, add
+`profile_id = "legacy-development"` to `ai-dlc-profile.toml`, commit it, and
+normal-enroll with that exact same stable ID:
+
+```sh
+ai-dlc machine enroll SOURCE --profile-id legacy-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG
+ai-dlc machine enroll SOURCE --profile-id legacy-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG --apply
+```
+
+For an immutable advertised tag or ref, enroll that same ref on each additional
+machine and expect `ai-dlc machine sync` to be idempotent. For an intentionally
+movable advertised branch, `ai-dlc machine sync` previews later changes and
+`ai-dlc machine sync --apply` activates a verified candidate. To move between
+immutable tags, reenroll with the new ref. In every case, edit each machine
+binding independently. Move every credential value into a password manager or
+keychain that injects its configured environment-variable name; neither AI-DLC
+files nor `.env` files are a credential store.
+
 Initialize the specification provider (OpenSpec by default) using its supplied setup instructions, review existing formal specs, and link them to work. Configure the personal knowledge provider (Obsidian by default) with the intended vault and validate access. Preserve repository architecture, product rationale, decisions and runbooks as durable docs rather than copying them into the vault.
 
 Adopting an existing project previews changes and reports path conflicts. Resolve user-authored docs/config deliberately before adoption; do not overwrite them. For upgrades, preserve Copier answers and the original accessible Git release. Bundled local-source adoption is a development fallback and does not promise cross-machine sync. Use the versioned repository template source for released projects.
 
 Provider changes require `project rebind` planning. Existing work retains its old provider until explicitly mapped. An apply refuses affected work without replacement artifact mappings. TOML mappings use work IDs as tables and artifact kinds as keys, for example `[work-123]` with `tracker = "NEW-42"`. PR/branch references must both be mapped when both exist. Local completion claims alone do not prove completion, so the migration treats retained records conservatively. Review old and replacement artifacts before applying.
 
-No Jira, Figma, Windows or hosted orchestration migration is provided by this release.
+No Jira, Figma, Windows, hosted orchestration, Obsidian create/attach, or
+provider-discovery migration is provided by this release. Local CLI and MCP
+execution remain the current control plane; hosted or cloud execution is a
+later qualification target.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -9,3 +9,56 @@ Docker Desktop on Apple silicon built the provider-test image from the attested 
 Machine provisioning and personal-agent integration pass deterministic local integration tests, including preview, owned updates, collision/drift refusal, runtime activation, and environment-reference-only credentials. A live client walkthrough is still outstanding. See the implementation record for reviewed boundaries. A disposable work-cycle walkthrough in `sandbox-aidlc` created one Linear issue, proved idempotent publish, bound a Git branch, transitioned the issue to In Progress, read the canonical remote state, and proved completion remained blocked before PR merge and merged-revision CI. After merge, completion authenticated the merged revision, downloaded and validated all five platform receipts from the successful target-branch run, and only then transitioned the sandbox issue to Done. No production Linear workspace was accessed and no package publication was performed.
 
 A disposable clean clone completed the declared devcontainer post-create bootstrap and all required checks on Linux ARM64. Its project virtual environment is isolated in a per-devcontainer named volume so Linux executables cannot replace the host checkout's `.venv`. The Codex Cloud setup and maintenance entry scripts and the Claude Cloud setup entry script also completed in that clean Linux container; this validates their bootstrap behavior only, not either hosted platform's authentication, persistence, or network lifecycle.
+
+## Portable profile enrollment candidate — 2026-09-04
+
+The source bootstrap completed in the linked implementation worktree. The reviewed
+`portable-profile-enrollment` work record parsed through the locked project
+environment and remained local with no tracker artifact. Existing ignored sandbox
+probe metadata identifies the designated sandbox team but does not contain the
+native workflow status IDs required by the work service. No Linear publication,
+transition, discovery, or other remote mutation was attempted; provider publication
+is deferred to the provider-onboarding cycle.
+
+A disposable Git repository outside the checkout was populated from
+`profiles/example/ai-dlc-profile.toml` and exercised with temporary XDG config,
+cache, and state roots. Enrollment preview left active state unchanged. Enrollment
+apply created only the isolated schema-1 lock and schema-4 machine file. Status then
+reported `example-development`, a 40-character pinned commit, a healthy cache, and
+the expected unbound `linear-sandbox` requirement. Machine plan used the same locked
+commit, remained a preview, and reported clean agent configuration. The local source
+was correctly classified as nonportable, the immutable cache contained only the
+declared profile file, `HOME` was not replaced, no machine apply targeted the real
+user home, and the disposable directory was removed after evidence capture.
+
+Packaging and security verification built both the source distribution and the real
+`ai_dlc-0.4.0-py3-none-any.whl`. The focused credential, enrollment, profile-source,
+machine, and machine-integration suite passed 252 tests; the final review's affected
+configuration, profile-source, CLI, and template suite passed 497 tests; generated-file
+drift checks passed. The bounded token-setting compatibility correction then passed
+23 focused config/cache security cases, all 186 configuration and profile-source tests,
+and 163 affected lifecycle tests. Initial wheel inspection found that the prior
+directory-wide profile asset rule still included the legacy user-named profile. A
+regression-first packaging fix limited the wheel to the base profile and the two
+approved public examples, and the final review applied the same exclusion to the
+source distribution.
+The rebuilt wheel contains 741 members and the rebuilt source distribution contains
+1,474 members. Each contains exactly the three approved public profile assets and no
+`.ai-dlc/local` state, enrollment lock, unexpected machine binding, environment file,
+Git metadata, legacy user-named profile, checkout path, or user-specific content
+marker.
+
+The required project gate ran through the bootstrap PATH and locked environment with
+its receipt written under ignored `.ai-dlc/local/`. All five required outcomes passed:
+generated, format, lint, types, and 785 tests. The portable enrollment OpenSpec change
+was strictly validated while active, archived at
+`openspec/changes/archive/2026-09-03-portable-profile-enrollment/`, and promoted to a
+strictly valid canonical capability spec. The work record now resolves that exact
+archive path. This is pre-commit local candidate evidence; the receipt correctly
+records a dirty checkout and does not establish merged-revision CI.
+
+This evidence does not qualify a factory-clean machine, either hosted cloud runtime,
+provider onboarding or discovery, Obsidian create/attach, behavioral skill quality,
+live client sessions, published package assets, or release readiness. The
+complete-branch independent review is complete; PR checks, merge, and merged-revision
+verification remain separate integration gates.

--- a/docs/reviews/2026-09-03-portable-profile-enrollment.md
+++ b/docs/reviews/2026-09-03-portable-profile-enrollment.md
@@ -1,0 +1,103 @@
+# Portable profile enrollment review record
+
+## Status and review basis
+
+This record catalogs the independent task reviews completed during implementation of
+the approved [portable profile enrollment design](../superpowers/specs/2026-09-03-portable-profile-enrollment-design.md)
+and [implementation plan](../superpowers/plans/2026-09-03-portable-profile-enrollment.md).
+The branch starts from `b256acd` and the last reviewed Task 9 revision is `6c490f4`.
+Task briefs, implementation reports, review diffs, findings, fix rounds, and re-review
+outcomes are retained in the ignored SDD execution ledger.
+
+The complete branch through Task 10 was independently reviewed across
+`b256acd..5c3e885`. That review found four Important gaps and one Minor documentation
+gap. A subsequent re-review confirmed the four original behavioral findings were fixed
+and the documentation correction was present, but found a compatibility regression in
+the sensitive-field normalization. The bounded adjudicated correction below is locally
+verified; independent approval of that correction remains pending.
+
+## Completed independent task reviews
+
+| Task | Reviewed revisions | Findings and disposition |
+| --- | --- | --- |
+| 0 — records and OpenSpec | `b3065ae`, `262fde4` | One Important capability-delta finding was corrected; re-review was clean. |
+| 1 — credential declarations | `96f1796` | The only objection conflicted with the plan's required `source` field; the recorded ruling retained the non-secret resolver identity with no code change and no open finding. |
+| 2 — enrollment persistence | `dac852c`, `917e026`, `23efda6` | Atomic machine creation, a real lock-replacement failure boundary, warning-free schema serialization, and the public `schema` contract were corrected; re-review was clean. |
+| 3 — verified Git cache | `ee4718c`, `2dba762` | Unadvertised pseudoref, raw-SHA, wildcard, and refspec acceptance was closed; re-review had no open correctness finding. |
+| 4 — runtime resolution | `b7de50b`, `bcd4826` | Explicit personal replacement no longer verifies the replaced enrolled cache while inheriting the machine scope; re-review was clean. |
+| 5 — enrollment services | `0352ebe`, `4ccd52e`, `9a60db0`, `7f7330e`, `2ac97e6`, `e579e23` | Review rounds corrected source redaction and grammar, lock-last result construction, ownership-error classification, stable portability, default modules, and ambiguous Git syntax. The final cwd-shadow source-identity correction was explicitly carried into Task 6. |
+| 6 — reconcile, sync, doctor | `c6e7b31`, `3466c74`, `96c7fa8`, `28eac5d` | The carried source-identity issue and findings in error redaction, Linear readiness, degraded doctor behavior, legacy sync, and explicit environment isolation were corrected; re-review was clean. |
+| 7 — CLI lifecycle | `169e386`, `9c5dc2e`, `474d1c3` | Reviews corrected matching-scope overrides, `--home` forwarding, root-doctor help, and explicit-machine readiness semantics; re-review was clean. |
+| 8 — end-to-end proof | `2fa3ed8`, `c78e260` | One Major test-quality finding showed preview checks could miss newly created files. Complete tree snapshots and a mutation proof corrected it; re-review was clean. |
+| 9 — public example and guidance | `d8e1c54`, `fd6f485`, `682d603`, `d2da010`, `6ff2687`, `6c490f4` | Review rounds corrected provider linkage, real-wheel validation, CLI/MCP boundaries, migration and ref guidance, ignored-local ownership, and executable privacy/handbook safeguards. The final re-review was clean. |
+
+Across these reviews, the load-bearing corrections covered atomic metadata
+publication, active-lock preservation, exact advertised Git refs, source parsing and
+redaction, explicit environment isolation, enrolled/explicit scope compatibility,
+complete preview no-write detection, and public artifact privacy. Each correctness,
+security, compatibility, or test-quality finding recorded as open by a task reviewer
+was resolved or explicitly carried into and resolved by the next task before that task
+was accepted.
+
+## Residual review notes
+
+- Task 3 recorded two deferred Minor coverage suggestions: direct cache-integrity
+  cases for missing, extra, or symlinked cache entries, and more direct portability
+  classification cases. The implementation rejects non-exact cache trees, later
+  integration tests cover corruption isolation, and subsequent source-grammar tests
+  exercise HTTPS, SSH, SCP, file, and local classifications; the original granular
+  cache-entry suggestions were not separately promoted to release blockers.
+- External package managers can leave partial side effects when reconciliation fails;
+  AI-DLC reports that boundary while preserving its own active lock and cache metadata.
+- The Task 10 real-wheel audit found a legacy user-named profile still packaged by a
+  directory-wide asset rule. A real-wheel regression failed first, the package rule was
+  narrowed to the three approved public profile assets, and the rebuilt wheel passed.
+- Linear publication remains local-only because the existing sandbox configuration
+  lacks native workflow status IDs. No alternate workspace was queried and no IDs were
+  guessed.
+
+## Complete-branch independent review findings and fix round
+
+- Review range: `b256acd..5c3e885`
+- Secret containment — Important: normalized tokenization now rejects common
+  secret-shaped provider fields such as `api_token`, `client_secret`, camel-case,
+  hyphenated, and key variants before cache activation. Exact credential declarations
+  and explicitly named environment references remain valid; literal values disguised
+  as environment references fail validation, while benign lookalikes remain accepted.
+- Git transport trust — Important: canonical cleartext `http://` sources now fail the
+  shared source classifier before any Git invocation. HTTPS, SSH, SCP, file URLs, and
+  local paths retain their prior classifications.
+- Scope composition — Important: `profile show` now always delegates to enrolled-aware
+  runtime resolution. An explicit personal or machine file replaces only its matching
+  layer, retains the opposite enrolled layer, and composes with an explicit project
+  file while preserving value provenance.
+- Distribution privacy — Important: the sdist now excludes the legacy user-named
+  profile as the wheel already does. The real-artifact regression builds and inspects
+  both distributions, requires exactly the three approved public profile assets, and
+  rejects enrollment state, local state, environment files, Git metadata, and
+  user-specific content.
+- Archived documentation — Minor: archived design links now resolve from their moved
+  directory, and the canonical capability has the approved purpose instead of the
+  archive-generated placeholder.
+- Re-review outcome — compatibility: re-review confirmed the four original behavioral
+  findings were fixed, then found that plural normalization classified benign schema-4
+  integer provider settings `max_tokens = 1024` and `token_count = 10` as credential
+  values.
+- Adjudicated correction: the grammar now exempts only those two normalized token-metric
+  shapes when their values are integers. Exact `token`, singular and plural API token
+  fields, access-token fields, client-secret fields, normalized camel-case and
+  hyphenated variants, and string values under the token-metric names remain prohibited
+  before cache activation. Explicit environment-reference fields remain valid.
+- Verification: each behavioral finding, including the compatibility regression, was
+  reproduced with a focused failing test before its implementation change and then
+  passed its focused regression. Final formatting, typing, generated-file, artifact,
+  and required-gate evidence is recorded in the release verification document.
+- Decision: the original findings are resolved and the bounded compatibility correction
+  is implemented and locally verified. This record does not claim independent approval
+  of that correction.
+
+The single allowed final fix/re-review loop is complete. Its remaining concrete
+compatibility regression was treated as load-bearing and corrected under the
+documented bounded adjudication, so no known review finding remains open; this does
+not claim independent approval of the correction. Integration still depends on fresh
+controller verification and the required pull request and merged-revision CI.

--- a/docs/superpowers/plans/2026-09-03-portable-profile-enrollment.md
+++ b/docs/superpowers/plans/2026-09-03-portable-profile-enrollment.md
@@ -1,0 +1,1097 @@
+# Portable Profile and Machine Enrollment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make AI-DLC able to enroll a secret-free personal profile from an exact Git revision, bind that profile to one machine without copying secrets, resolve it automatically with project configuration, and safely plan, apply, synchronize, inspect, and diagnose the resulting machine.
+
+**Architecture:** Keep the portable profile, project configuration, machine binding, credential values, and generated client files as separate ownership layers. A Git-backed profile store materializes an immutable, digest-verified cache; a small enrollment store owns the active lock and machine file; the existing configuration and provisioning services consume those resolved paths; and a thin `machine` CLI exposes preview-first lifecycle operations. Existing schema-4 files and `setup`, `profile show`, `doctor`, and `--machine` entry points remain compatible.
+
+**Tech Stack:** Python 3.12, Typer, Pydantic 2, `tomllib`, `tomli-w`, Git CLI, pytest, Ruff, Pyright, existing atomic-write and agent-rendering utilities.
+
+**Spec:** [Portable Profile and Machine Enrollment Design](../specs/2026-09-03-portable-profile-enrollment-design.md)
+
+## Global Constraints
+
+- Preserve the unrelated worktree files `.DS_Store`, `.ai-dlc/.DS_Store`, and `target/.rustc_info.json`; never stage, edit, or delete them.
+- Never read, print, copy, stage, or serialize values from `.ai-dlc/local/linear.env` or `.ai-dlc/local/.linear.env.swp`.
+- Never put a credential value in a profile, lock, machine binding, cache receipt, plan, error, journal, generated client file, or test snapshot. Tests must use unmistakably fake sentinel values and assert their absence from persisted files and returned structures.
+- Keep schema 4 for base, personal, project, and machine configuration. Enrollment locks use schema 1.
+- Add no runtime dependency. Invoke Git with argument arrays and `shell=False` behavior through `subprocess.run`.
+- Treat the checked-out public repository as product source, not as the user's portable personal-profile repository. Tests create disposable Git repositories; documentation explains how to create the separate private repository.
+- Make every state-changing lifecycle action preview-first. `enroll`, `migrate`, and `sync` change active state only with `--apply`; `machine plan` never writes; `machine apply` is the explicit workstation/client mutation.
+- Write AI-DLC-owned metadata atomically. Activate a new lock last. A failed candidate validation or reconciliation must leave the prior lock byte-for-byte unchanged.
+- Resolve configuration in the fixed order base → personal → project → machine. An explicit personal or machine file replaces the enrolled file in that scope; it is not a fifth precedence layer.
+- Preserve user-authored Codex, Claude, shell, and MCP configuration through the existing ownership checks.
+- Do not perform a live Linear mutation as part of the automated tests. The final dogfood step may use only the already-designated `sandbox-aidlc` workspace and only when its team/status configuration is complete.
+
+## Spec Coverage Map
+
+| Approved design area | Implemented and verified in |
+|---|---|
+| Secret-free profile identity and credentials | Tasks 1, 3, and 9 |
+| XDG enrollment lock, cache, and machine binding | Tasks 2, 3, and 5 |
+| Fixed configuration precedence and explicit overrides | Task 4 |
+| Preview-first enroll, migrate, status, plan, apply, sync, and doctor | Tasks 5, 6, and 7 |
+| Exact Git revisions, offline cache, integrity, and transaction failures | Tasks 3, 6, and 8 |
+| Current CLI/schema compatibility | Tasks 1, 4, 6, and 7 |
+| Two-machine proof, client ownership, and secret redaction | Task 8 |
+| Public examples, handbook, migration, and honest follow-on gaps | Tasks 9 and 10 |
+| Dogfood record, formal specification, review, CI, PR, and merge | Tasks 0 and 10 |
+
+---
+
+### Task 0: Bind the approved design to AI-DLC's own work and specification records
+
+**Files:**
+
+- Create: `.ai-dlc/work/portable-profile-enrollment.toml`
+- Create: `openspec/changes/portable-profile-enrollment/proposal.md`
+- Create: `openspec/changes/portable-profile-enrollment/design.md`
+- Create: `openspec/changes/portable-profile-enrollment/tasks.md`
+
+- [ ] **Step 1: Create the reviewed work record**
+
+Create `.ai-dlc/work/portable-profile-enrollment.toml` with this exact initial content:
+
+```toml
+schema = 1
+id = "portable-profile-enrollment"
+title = "Implement portable profile and machine enrollment"
+scope = "Enroll a secret-free personal profile from an exact Git revision, bind it per machine, and safely resolve, reconcile, synchronize, inspect, and diagnose it."
+requires_spec = true
+spec_reason = "Changes configuration ownership, credential references, machine state, CLI behavior, and synchronization guarantees."
+acceptance = [
+  "Two isolated machines resolve one pinned profile with distinct local bindings",
+  "Preview, apply, sync, status, and doctor preserve active state on failure",
+  "Credentials remain external and no secret value is persisted or returned",
+  "Existing schema-4 and setup/profile/doctor interfaces remain compatible",
+  "Required project checks and independent review pass",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/portable-profile-enrollment"
+branch = "codex/portable-profile-enrollment"
+```
+
+- [ ] **Step 2: Translate the approved design into the repository's OpenSpec shape**
+
+Create:
+
+- `proposal.md` with Why, What Changes, Capabilities, and Impact sections;
+- `design.md` with the five ownership layers, lock/cache transaction, precedence, credential boundary, command/service boundary, compatibility strategy, and explicit non-goals;
+- `tasks.md` with Tasks 1–10 in this plan as unchecked implementation groups and a note that Task 0 is the already-completed bootstrap record.
+
+The OpenSpec documents summarize and link to the approved detailed design. They do not invent requirements or duplicate the full 367-line design verbatim.
+
+- [ ] **Step 3: Validate the work and specification records**
+
+Run:
+
+```sh
+ai-dlc work status portable-profile-enrollment
+openspec validate portable-profile-enrollment --strict --no-interactive
+git diff --check
+```
+
+Expected: the work record parses and the active OpenSpec change validates. `work status` may report no tracker artifact because publication is deliberately deferred until non-secret sandbox IDs are available.
+
+- [ ] **Step 4: Commit Task 0**
+
+Run:
+
+```sh
+git add .ai-dlc/work/portable-profile-enrollment.toml openspec/changes/portable-profile-enrollment
+git commit -m "docs: specify portable profile enrollment"
+```
+
+---
+
+### Task 1: Add portable credential declarations and machine bindings
+
+**Files:**
+
+- Create: `src/ai_dlc/credentials.py`
+- Modify: `src/ai_dlc/config.py`
+- Modify: `tests/test_config.py`
+- Create: `tests/test_credentials.py`
+
+- [ ] **Step 1: Write failing scope and merge tests**
+
+Add tests to `tests/test_config.py` that establish the schema contract:
+
+```python
+def test_personal_credential_requirement_and_machine_binding_merge():
+    from ai_dlc.config import resolve_layers
+
+    result = resolve_layers(
+        [
+            (
+                "personal",
+                {
+                    "schema": 4,
+                    "profile_id": "sean-development",
+                    "credentials": {
+                        "linear-sandbox": {
+                            "description": "Linear sandbox access",
+                            "required_by": ["provider.linear-sandbox"],
+                        }
+                    },
+                },
+            ),
+            (
+                "machine",
+                {
+                    "schema": 4,
+                    "credentials": {
+                        "linear-sandbox": {
+                            "source": "environment",
+                            "variable": "LINEAR_SANDBOX_TOKEN",
+                        }
+                    },
+                },
+            ),
+        ]
+    )
+
+    assert result.values["credentials"]["linear-sandbox"] == {
+        "description": "Linear sandbox access",
+        "required_by": ["provider.linear-sandbox"],
+        "source": "environment",
+        "variable": "LINEAR_SANDBOX_TOKEN",
+    }
+    assert result.sources["credentials.linear-sandbox.description"] == "personal"
+    assert result.sources["credentials.linear-sandbox.variable"] == "machine"
+```
+
+Also test all invalid placements:
+
+- `profile_id` is allowed only in a personal layer;
+- personal credentials reject `source` and `variable`;
+- machine credentials reject `description` and `required_by`;
+- machine credential sources other than `environment` fail;
+- credential IDs and environment variable names must be stable slugs/identifiers;
+- secret-shaped value fields remain rejected recursively.
+
+- [ ] **Step 2: Run the focused config tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_config.py -q
+```
+
+Expected: the new tests fail because `profile_id` and `credentials` are unknown fields.
+
+- [ ] **Step 3: Implement scope validation**
+
+In `src/ai_dlc/config.py`:
+
+- add `profile_id` to the personal scope only;
+- add `credentials` to personal and machine scopes;
+- validate credential tables per layer before recursive merging;
+- require logical IDs to match `^[a-z0-9][a-z0-9-]*$`;
+- require environment variable names to match `^[A-Z_][A-Z0-9_]*$`;
+- require personal entries to contain `description` and a string list `required_by`;
+- require machine entries to contain only `source = "environment"` and `variable`;
+- keep machine providers restricted to the existing account/reference fields.
+
+Use small private helpers such as `_validate_credentials(layer, value)` rather than adding credential-specific branches to the merge algorithm.
+
+- [ ] **Step 4: Write failing redaction and legacy-normalization tests**
+
+Create `tests/test_credentials.py` with these behaviors:
+
+```python
+def test_status_reports_presence_without_returning_environment_value(monkeypatch):
+    from ai_dlc.credentials import credential_status
+
+    marker = "fake-value-that-must-not-escape"
+    monkeypatch.setenv("LINEAR_SANDBOX_TOKEN", marker)
+    config = {
+        "credentials": {
+            "linear-sandbox": {
+                "description": "Linear sandbox access",
+                "required_by": ["provider.linear-sandbox"],
+                "source": "environment",
+                "variable": "LINEAR_SANDBOX_TOKEN",
+            }
+        }
+    }
+
+    result = credential_status(config)
+
+    assert result == [
+        {
+            "id": "linear-sandbox",
+            "description": "Linear sandbox access",
+            "required_by": ["provider.linear-sandbox"],
+            "source": "environment",
+            "variable": "LINEAR_SANDBOX_TOKEN",
+            "configured": True,
+            "present": True,
+        }
+    ]
+    assert marker not in repr(result)
+```
+
+Add tests that:
+
+- an unbound requirement is `configured = False` and `present = False`;
+- an unset bound variable is configured but not present;
+- a legacy provider with `token_env = "LINEAR_API_KEY"` appears as logical ID `provider.<provider-id>` only when no explicit credential covers it;
+- supplied `environ: Mapping[str, str]` is honored without mutating `os.environ`;
+- results are sorted by logical ID.
+
+- [ ] **Step 5: Run the credential tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_credentials.py -q
+```
+
+Expected: collection fails because `ai_dlc.credentials` does not exist.
+
+- [ ] **Step 6: Implement the credential report**
+
+Create `src/ai_dlc/credentials.py` with the public interface:
+
+```python
+from collections.abc import Mapping
+from typing import Any
+
+
+def credential_status(
+    config: dict[str, Any],
+    environ: Mapping[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """Return credential readiness metadata without returning credential values."""
+```
+
+Normalize legacy `providers.<id>.token_env` references into the same report. Explicit logical requirements win over a synthetic legacy entry when their `required_by` contains `provider.<id>`. Inspect only key presence and nonempty value truthiness; never copy the value into a local returned object.
+
+- [ ] **Step 7: Verify and commit Task 1**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_config.py tests/test_credentials.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/config.py src/ai_dlc/credentials.py tests/test_config.py tests/test_credentials.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 1 files:
+
+```sh
+git add src/ai_dlc/config.py src/ai_dlc/credentials.py tests/test_config.py tests/test_credentials.py
+git commit -m "feat: model portable credential bindings"
+```
+
+---
+
+### Task 2: Model enrollment locks and XDG-owned paths
+
+**Files:**
+
+- Create: `src/ai_dlc/enrollment.py`
+- Create: `tests/test_enrollment.py`
+- Modify: `src/ai_dlc/files.py`
+
+- [ ] **Step 1: Write failing path, model, and atomicity tests**
+
+Create `tests/test_enrollment.py` covering:
+
+1. Explicit `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_STATE_HOME` produce:
+   - `config/ai-dlc/enrollment.toml`;
+   - `config/ai-dlc/machines/<machine-id>.toml`;
+   - `cache/ai-dlc/profiles/<profile-id>/<commit>/`;
+   - `state/ai-dlc/`.
+2. With no XDG variables, a supplied home uses `.config`, `.cache`, and `.local/state` fallbacks.
+3. `EnrollmentLock` accepts exactly schema 1, a stable profile ID, a stable machine ID, a 40-character lowercase Git commit, a 64-character lowercase SHA-256 digest, a relative subdirectory, and a relative profile file.
+4. Absolute paths, `..`, empty IDs, uppercase IDs, unknown lock fields, malformed commits, and malformed digests fail before a write.
+5. `write_lock` produces parseable TOML, mode `0600`, and an atomic final file.
+6. `ensure_machine_file` creates only `schema = 4`, uses mode `0600`, and never replaces an existing file.
+7. Replacing a lock through a deliberately failing writer leaves its prior bytes intact. Extend `atomic_write` only if the current helper cannot support this test.
+
+Use the exact model shape:
+
+```python
+class EnrollmentLock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema: Literal[1] = 1
+    profile_id: str
+    source: str
+    requested_ref: str
+    resolved_commit: str
+    content_sha256: str
+    machine_id: str
+    subdirectory: str = ""
+    profile_file: str = "ai-dlc-profile.toml"
+```
+
+- [ ] **Step 2: Run the enrollment tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_enrollment.py -q
+```
+
+Expected: collection fails because `ai_dlc.enrollment` does not exist.
+
+- [ ] **Step 3: Implement paths and validated persistence**
+
+Create `src/ai_dlc/enrollment.py` with this public surface:
+
+- immutable `EnrollmentPaths(config_root: Path, cache_root: Path, state_root: Path)`;
+- `EnrollmentPaths.from_environment(home: Path | None = None, environ: Mapping[str, str] | None = None) -> EnrollmentPaths`;
+- `EnrollmentPaths.lock_file -> Path`;
+- `EnrollmentPaths.machine_file(machine_id: str) -> Path`;
+- `EnrollmentPaths.profile_root(profile_id: str, resolved_commit: str) -> Path`;
+- `read_lock(paths: EnrollmentPaths) -> EnrollmentLock | None`;
+- `write_lock(paths: EnrollmentPaths, lock: EnrollmentLock) -> Path`;
+- `ensure_machine_file(paths: EnrollmentPaths, machine_id: str) -> Path`;
+- `active_profile_file(paths: EnrollmentPaths, lock: EnrollmentLock) -> Path`.
+
+Validate relative paths using `PurePosixPath`; reject absolute paths, empty components, `.` and `..`. Serialize with `tomli_w`. If `atomic_write` cannot set a private final mode safely, add an optional `mode: int | None = None` argument and preserve all existing callers' behavior when it is omitted.
+
+- [ ] **Step 4: Verify and commit Task 2**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_enrollment.py tests/test_user_agents.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/enrollment.py src/ai_dlc/files.py tests/test_enrollment.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass, including existing ownership-file behavior.
+
+Commit only the Task 2 files:
+
+```sh
+git add src/ai_dlc/enrollment.py src/ai_dlc/files.py tests/test_enrollment.py
+git commit -m "feat: persist machine enrollment state"
+```
+
+---
+
+### Task 3: Resolve Git sources into an immutable verified cache
+
+**Files:**
+
+- Create: `src/ai_dlc/profile_source.py`
+- Create: `tests/test_profile_source.py`
+
+- [ ] **Step 1: Write a reusable disposable-Git fixture**
+
+In `tests/test_profile_source.py`, add a helper that initializes a temporary Git repository, configures a local test identity, writes `ai-dlc-profile.toml`, commits it, and returns the repository path and exact commit. Keep the fixture local; no network access is required.
+
+The normal manifest should be:
+
+```toml
+schema = 4
+profile_id = "test-development"
+
+[modules]
+include = ["core"]
+
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+```
+
+- [ ] **Step 2: Write failing resolution and cache tests**
+
+Test these behaviors:
+
+- resolving `main` yields the exact 40-character commit and a deterministic 64-character bundle digest;
+- the materialized cache contains only the declared profile file without `.git` metadata;
+- unrelated files in the selected repository/subdirectory are not copied into the cache;
+- a relative `subdirectory` works and cannot escape the repository;
+- `profile_id` must match the normal manifest;
+- normal enrollment rejects a missing `profile_id`;
+- legacy resolution accepts an explicit relative `profile_file` that omits `profile_id`;
+- a manifest containing a secret-shaped field is rejected before cache activation;
+- a profile path that is a symlink or non-regular file is rejected;
+- a second resolution reuses a byte-identical cache;
+- an existing cache with changed bytes is reported as corrupt, never silently replaced;
+- resolving a moved branch produces a new candidate commit while the old cache remains valid;
+- an invalid or ambiguous ref fails without changing any existing cache;
+- `verify_cached_profile(lock, paths)` works with the source repository unavailable;
+- local repository sources are marked `portable = False`.
+
+The public result type is:
+
+```python
+@dataclass(frozen=True)
+class ProfileCandidate:
+    profile_id: str
+    source: str
+    requested_ref: str
+    resolved_commit: str
+    content_sha256: str
+    subdirectory: str
+    profile_file: str
+    cache_root: Path
+    portable: bool
+```
+
+- [ ] **Step 3: Run the profile-source tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_profile_source.py -q
+```
+
+Expected: collection fails because `ai_dlc.profile_source` does not exist.
+
+- [ ] **Step 4: Implement deterministic Git resolution**
+
+Create `src/ai_dlc/profile_source.py` with these public call signatures:
+
+- `resolve_profile_source(source: str, profile_id: str, requested_ref: str, paths: EnrollmentPaths, *, subdirectory: str = "", profile_file: str = "ai-dlc-profile.toml", allow_legacy_identity: bool = False) -> ProfileCandidate`;
+- `verify_cached_profile(lock: EnrollmentLock, paths: EnrollmentPaths) -> Path`.
+
+Implementation requirements:
+
+1. Clone to a temporary directory under the AI-DLC cache parent with no checkout, fetch only the requested ref, resolve `FETCH_HEAD^{commit}`, then check out that exact detached commit.
+2. Pass every subprocess argument separately and include bounded timeout/error handling. Never interpolate source/ref text into a shell command.
+3. Resolve and validate only the selected relative profile file. Reject symlinks, non-regular files, and path escapes. Do not copy unrelated repository or subdirectory content.
+4. Validate the profile by passing it through the personal-layer schema validator. Normal manifests require matching `profile_id`; legacy files may omit it but must match if present.
+5. Calculate the digest from the profile's POSIX relative path, byte length, and contents. Do not include mtimes, ownership, absolute paths, unrelated files, or Git metadata.
+6. Copy to a temporary sibling and rename it into `<profile-id>/<commit>` only after validation. If the destination exists, verify its digest and reuse it or fail as corrupt.
+7. Clean up temporary clones on success and failure.
+8. Treat existing local paths and `file://` Git sources as nonportable; HTTPS, SSH URL, and SCP-style Git remotes are portable metadata.
+
+- [ ] **Step 5: Verify and commit Task 3**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_profile_source.py tests/test_config.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/profile_source.py tests/test_profile_source.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 3 files:
+
+```sh
+git add src/ai_dlc/profile_source.py tests/test_profile_source.py
+git commit -m "feat: materialize pinned profile sources"
+```
+
+---
+
+### Task 4: Resolve enrolled configuration automatically and preserve precedence
+
+**Files:**
+
+- Modify: `src/ai_dlc/config.py`
+- Modify: `tests/test_config.py`
+- Modify: `tests/test_enrollment.py`
+
+- [ ] **Step 1: Write failing runtime-resolution tests**
+
+Add tests for a new high-level resolver while preserving `resolve_files` as an explicit, side-effect-free primitive:
+
+```python
+def test_runtime_resolution_uses_enrolled_files_and_fixed_precedence(tmp_path):
+    from ai_dlc.config import resolve_runtime
+
+    # Build XDG roots, a valid lock/cache, personal/project/machine files,
+    # then assert base → personal → project → machine values and provenance.
+```
+
+Cover these exact cases:
+
+- packaged `profiles/base.toml` is the default base layer;
+- a verified active cache supplies the personal layer;
+- `<root>/ai-dlc.toml` supplies the project layer only when it exists;
+- the lock's machine ID selects exactly one machine file;
+- `personal=` replaces the enrolled personal path but still precedes project;
+- `machine=` replaces the enrolled machine path but cannot weaken project checks;
+- no active enrollment is valid and simply omits personal/machine layers;
+- a present lock with a missing, changed, or malformed cache is an error rather than a silent fallback;
+- two different homes/XDG roots cannot see each other's enrollment;
+- returned provenance stays `base`, `personal`, `project`, or `machine`.
+
+- [ ] **Step 2: Run the focused tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_config.py tests/test_enrollment.py -q
+```
+
+Expected: the new tests fail because `resolve_runtime` does not exist.
+
+- [ ] **Step 3: Implement the high-level resolver**
+
+Add this public call signature to `src/ai_dlc/config.py`: `resolve_runtime(root: Path | None = None, *, base: Path | None = None, personal: Path | None = None, machine: Path | None = None, home: Path | None = None, environ: Mapping[str, str] | None = None, enrollment_paths: EnrollmentPaths | None = None) -> Resolved`.
+
+Use local imports for enrollment/profile-cache helpers if needed to avoid an import cycle. If either explicit scope is absent, consult the active lock; explicit files replace only their matching enrolled scope. Include the project file only when `root` is supplied and `root / "ai-dlc.toml"` exists. Keep `resolve_layers`, `resolve_files`, and `load_project` deterministic and enrollment-independent for unit tests and project-only operations.
+
+- [ ] **Step 4: Verify and commit Task 4**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_config.py tests/test_enrollment.py tests/test_project.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/config.py tests/test_config.py tests/test_enrollment.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 4 files:
+
+```sh
+git add src/ai_dlc/config.py tests/test_config.py tests/test_enrollment.py
+git commit -m "feat: resolve enrolled configuration"
+```
+
+---
+
+### Task 5: Add preview-first enrollment, migration, and status services
+
+**Files:**
+
+- Create: `src/ai_dlc/machine.py`
+- Create: `tests/test_machine.py`
+
+- [ ] **Step 1: Write failing enrollment-service tests**
+
+Create `tests/test_machine.py` using the disposable Git helper or move that helper to `tests/conftest.py` if both modules need it. Test `MachineManager.enroll`:
+
+- preview resolves and caches a candidate but does not create a lock or machine file;
+- the preview reports source, requested ref, exact commit, digest, portability, proposed lock, required bindings, missing credential variable names, selected modules, user-level MCP changes, and ownership conflicts;
+- preview and error output never contain environment values;
+- `apply=True` creates a schema-4 machine skeleton if absent and activates the lock last;
+- enrollment performs no package-manager command and no client-config write;
+- reenrolling the same candidate is idempotent;
+- explicit enrollment may replace a different profile ID, and the preview clearly reports that change;
+- a profile-ID mismatch fails before any active-state write.
+
+Test `MachineManager.migrate`:
+
+- it requires an explicit relative `profile_file`;
+- it accepts a pinned schema-4 personal file with no `profile_id`;
+- the compatibility lock records that exact file path;
+- it has the same preview/apply behavior as enrollment;
+- it never rewrites the source file.
+
+- [ ] **Step 2: Write failing status tests**
+
+Test status for:
+
+- no enrollment: `enrolled = False`, no exception, and an actionable next step;
+- healthy enrollment: identity, commit, source portability, machine file, cache health, credential readiness, and drift all reported without secret values;
+- missing machine binding: reported as configuration drift;
+- missing credential variable: reported by logical ID and variable name;
+- corrupt cache: `cache = "corrupt"` and `ready = False` without fetching;
+- source repository removed: healthy cached status remains available offline.
+
+- [ ] **Step 3: Run the machine tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_machine.py -q
+```
+
+Expected: collection fails because `ai_dlc.machine` does not exist.
+
+- [ ] **Step 4: Implement `MachineManager` enrollment and status**
+
+Create `src/ai_dlc/machine.py` with dependency-injectable construction and these public call signatures:
+
+- `MachineManager(*, home: Path | None = None, environ: Mapping[str, str] | None = None, paths: EnrollmentPaths | None = None)`;
+- `enroll(source: str, profile_id: str, machine_id: str, *, requested_ref: str = "main", subdirectory: str = "", apply: bool = False) -> dict[str, object]`;
+- `migrate(source: str, profile_file: str, profile_id: str, machine_id: str, *, requested_ref: str = "main", subdirectory: str = "", apply: bool = False) -> dict[str, object]`;
+- `status(root: Path | None = None) -> dict[str, object]`.
+
+Factor normal/legacy candidate handling into one private method. Generate previews from the candidate personal configuration plus the proposed/current machine binding. Use `credential_status` and `render_user_agents(candidate_config, apply=False)` for readiness and client changes. On enrollment apply, create or preserve the machine file first and write the validated lock last. Do not call `provision.machine_apply` here.
+
+- [ ] **Step 5: Verify and commit Task 5**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_machine.py tests/test_profile_source.py tests/test_user_agents.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/machine.py tests/test_machine.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 5 files:
+
+```sh
+git add src/ai_dlc/machine.py tests/test_machine.py
+git commit -m "feat: enroll portable machine profiles"
+```
+
+---
+
+### Task 6: Reconcile, synchronize, and diagnose the enrolled machine
+
+**Files:**
+
+- Modify: `src/ai_dlc/provision.py`
+- Modify: `src/ai_dlc/machine.py`
+- Modify: `tests/test_provision.py`
+- Modify: `tests/test_machine.py`
+
+- [ ] **Step 1: Write failing provisioning-layer tests**
+
+Update `tests/test_provision.py` to require:
+
+- `machine_plan(profile, machine=machine_path)` merges personal then machine scope;
+- machine credential bindings and path/account choices are visible to readiness logic but do not alter executable provider behavior;
+- `machine_apply(profile, machine=machine_path)` renders the merged agent configuration;
+- existing callers that provide only `profile` remain valid;
+- no secret environment value enters the returned plan or generated files.
+
+Change signatures compatibly to `machine_plan(profile: Path, headless: bool = False, system: str | None = None, architecture: str | None = None, home: Path | None = None, machine: Path | None = None) -> dict` and `machine_apply(profile: Path, headless: bool = False, home: Path | None = None, machine: Path | None = None) -> dict`.
+
+- [ ] **Step 2: Run provisioning tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_provision.py -q
+```
+
+Expected: new calls fail because `machine` is not accepted or merged.
+
+- [ ] **Step 3: Implement merged provisioning**
+
+Change both provisioning functions to call `resolve_files(personal=profile, machine=machine)`. Preserve current platform checks, package-manager delegation, setup journal behavior, runtime activation, preview behavior, and user-agent ownership safeguards.
+
+- [ ] **Step 4: Write failing manager plan/apply/sync/doctor tests**
+
+Extend `tests/test_machine.py` for:
+
+- `plan()` loads only the active verified cache and active machine binding, then delegates to `machine_plan` without writing;
+- `apply()` delegates to `machine_apply` and returns lock identity plus the existing reconciliation result;
+- `sync(apply=False)` fetches a moved requested ref and previews commit/config differences without changing lock bytes or client files;
+- `sync(apply=True)` reconciles against the candidate and writes the new lock only after success;
+- a failed candidate reconciliation leaves the prior lock bytes unchanged and labels any package-side effects as potentially partial;
+- invalid candidate content, corrupt cache, and fetch failure leave the active lock unchanged;
+- sync to the already-active commit is idempotent;
+- `doctor(root)` combines machine status, project runtime checks, agent-client rendering, native sign-ins, credentials, and provider health;
+- doctor never returns an environment value.
+
+Patch `ai_dlc.provision.machine_plan`, `machine_apply`, and `doctor` in unit tests. Use real Git only for source/ref behavior.
+
+- [ ] **Step 5: Run manager tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_machine.py -q
+```
+
+Expected: new tests fail because the lifecycle methods do not exist.
+
+- [ ] **Step 6: Implement the remaining manager lifecycle**
+
+Add these calls to `MachineManager`: `plan(*, headless: bool = False) -> dict[str, object]`, `apply(*, headless: bool = False) -> dict[str, object]`, `sync(*, apply: bool = False, headless: bool = False) -> dict[str, object]`, and `doctor(root: Path, *, target: str = "local") -> dict[str, object]`.
+
+Implementation order for `sync(apply=True)` is mandatory:
+
+1. read and retain the prior lock bytes;
+2. fetch, materialize, and validate a candidate without changing the lock;
+3. calculate the candidate diff and readiness report;
+4. call `machine_apply(candidate_profile, machine=active_machine_file)`;
+5. only after success, atomically write the candidate lock;
+6. on failure, report the failed step, retain candidate cache for safe reuse, and assert the active lock bytes are unchanged.
+
+Refactor `provision.doctor` to accept optional personal/home/environment inputs or add a compatible helper so both the root `doctor` command and `MachineManager.doctor` use the same checks. Credential readiness must come from `credentials.credential_status`, not duplicated environment logic.
+
+- [ ] **Step 7: Verify and commit Task 6**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_provision.py tests/test_machine.py tests/test_user_agents.py tests/test_workstation.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/provision.py src/ai_dlc/machine.py tests/test_provision.py tests/test_machine.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 6 files:
+
+```sh
+git add src/ai_dlc/provision.py src/ai_dlc/machine.py tests/test_provision.py tests/test_machine.py
+git commit -m "feat: reconcile and sync enrolled machines"
+```
+
+---
+
+### Task 7: Expose the machine lifecycle and retain compatibility aliases
+
+**Files:**
+
+- Modify: `src/ai_dlc/cli.py`
+- Modify: `tests/test_cli.py`
+
+- [ ] **Step 1: Write failing help and command-routing tests**
+
+Extend `tests/test_cli.py` to assert the root help includes `machine`, and machine help includes:
+
+- `enroll`;
+- `migrate`;
+- `plan`;
+- `apply`;
+- `sync`;
+- `status`;
+- `doctor`.
+
+Using monkeypatched `MachineManager` methods, assert routing and defaults for:
+
+```text
+ai-dlc machine enroll /tmp/profile-repo --profile-id test-development --machine-id test-mac
+ai-dlc machine enroll /tmp/profile-repo --profile-id test-development --machine-id test-mac --ref stable --subdirectory config --apply
+ai-dlc machine migrate /tmp/profile-repo --profile-file profiles/sean.toml --profile-id sean-development --machine-id personal-macbook
+ai-dlc machine plan
+ai-dlc machine apply
+ai-dlc machine sync
+ai-dlc machine sync --apply
+ai-dlc machine status
+ai-dlc machine doctor --root /tmp/project
+```
+
+Add compatibility tests proving:
+
+- `setup plan --profile <path>` and `setup apply --profile <path>` still call the existing provision functions;
+- `setup plan` and `setup apply` without `--profile` call the enrolled manager;
+- `profile show` without explicit files uses `resolve_runtime`;
+- an explicit `--machine` replaces enrolled machine scope for workflow and doctor calls;
+- root `doctor` and `machine doctor` share readiness semantics.
+
+- [ ] **Step 2: Run CLI tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_cli.py -q
+```
+
+Expected: help assertions and manager command calls fail because the group is absent.
+
+- [ ] **Step 3: Implement thin Typer commands**
+
+In `src/ai_dlc/cli.py`:
+
+- create and register `machine = typer.Typer(no_args_is_help=True)`;
+- make each command instantiate `MachineManager` and emit its JSON-safe result;
+- keep `--apply` false by default for enroll, migrate, and sync;
+- make `setup --profile` optional and route based on whether it was supplied;
+- change `config_for` to use `resolve_runtime(root, machine=machine)`;
+- change default `profile show` and root `doctor` to use enrolled resolution;
+- preserve explicit paths and all existing JSON/nonzero-exit behavior.
+
+Do not put Git, filesystem, credential, or provisioning logic in CLI functions.
+
+- [ ] **Step 4: Verify and commit Task 7**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_cli.py tests/test_workflow.py tests/test_provision.py -q
+uv run --locked --no-sync ruff check src/ai_dlc/cli.py tests/test_cli.py
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the Task 7 files:
+
+```sh
+git add src/ai_dlc/cli.py tests/test_cli.py
+git commit -m "feat: expose machine enrollment commands"
+```
+
+---
+
+### Task 8: Prove two-machine portability, offline behavior, and secret containment
+
+**Files:**
+
+- Create: `tests/test_machine_integration.py`
+- Modify: `tests/conftest.py`
+- Modify: `tests/test_user_agents.py`
+
+- [ ] **Step 1: Extract a shared local-Git fixture if needed**
+
+Move only the disposable profile-repository setup needed by multiple test modules into `tests/conftest.py`. The fixture must return explicit paths/commits and must not rely on the user's Git config, home directory, network, or credential environment.
+
+- [ ] **Step 2: Write the two-machine end-to-end test**
+
+Create `tests/test_machine_integration.py` with one high-value flow:
+
+1. Create one secret-free Git profile with a credential requirement and one MCP server using an environment variable reference.
+2. Create `machine-a` and `machine-b` with entirely separate home/config/cache/state directories.
+3. Enroll both against the same exact commit.
+4. Write distinct machine bindings mapping the same logical credential to `LINEAR_A_TOKEN` and `LINEAR_B_TOKEN`.
+5. Supply different fake sentinel environment values in memory.
+6. Assert both machines resolve the same personal/profile digest and different machine provenance.
+7. Preview reconciliation for both without writes.
+8. Apply only agent rendering through a patched package/runtime boundary and assert generated Codex/Claude configuration contains environment variable names, never values.
+9. Remove the source Git repository and prove status/plan still work from verified caches.
+10. Scan every regular file in both temporary XDG/home trees and every returned JSON structure; neither sentinel value may appear.
+
+- [ ] **Step 3: Add adversarial transaction and ownership integration cases**
+
+Add tests for:
+
+- moving `main`, previewing sync, then failing reconciliation: old lock remains active;
+- retrying the same cached candidate successfully: new lock activates;
+- tampering with one machine's cache: that machine fails integrity while the other remains healthy;
+- a user-authored MCP ID collision: apply fails before lock change and authored bytes survive;
+- source fetch failure: active offline status remains healthy and sync reports an actionable failure;
+- legacy `profile_file` enrollment and sync for one compatibility window.
+
+- [ ] **Step 4: Run integration tests and fix only evidenced defects**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_machine_integration.py tests/test_user_agents.py -q
+```
+
+Expected: tests initially expose any integration defects. For each failure, use `superpowers:systematic-debugging`, add or tighten the smallest regression assertion, then change the responsible implementation module. Do not weaken integrity, atomicity, ownership, or redaction assertions.
+
+- [ ] **Step 5: Verify and commit Task 8**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_machine_integration.py tests/test_machine.py tests/test_user_agents.py -q
+uv run --locked --no-sync ruff format --check src tests
+uv run --locked --no-sync ruff check src tests
+uv run --locked --no-sync pyright --pythonpath .venv/bin/python
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit the integration tests plus only implementation fixes directly required by those tests:
+
+```sh
+git add tests/conftest.py tests/test_machine_integration.py tests/test_user_agents.py src/ai_dlc/config.py src/ai_dlc/credentials.py src/ai_dlc/enrollment.py src/ai_dlc/profile_source.py src/ai_dlc/machine.py src/ai_dlc/provision.py src/ai_dlc/user_agents.py
+git commit -m "test: prove portable enrollment end to end"
+```
+
+Before committing, inspect `git diff --cached --name-only` and unstage any unrelated source file.
+
+---
+
+### Task 9: Ship a nonpersonal profile example and update durable guidance
+
+**Files:**
+
+- Create: `profiles/example/ai-dlc-profile.toml`
+- Modify: `profiles/machines/example.toml`
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/development-workflow.md`
+- Modify: `docs/workflows/tool-map.md`
+- Modify: `docs/migration.md`
+- Modify: `project-templates/project/AI-DLC.md`
+- Modify: `project-templates/project/docs/development-workflow.md.jinja`
+- Modify: `project-templates/project/docs/workflows/tool-map.md`
+- Modify: `tests/test_templates.py`
+
+- [ ] **Step 1: Write failing packaged-example and generated-handbook tests**
+
+In `tests/test_templates.py`, assert:
+
+- the wheel asset path contains `profiles/example/ai-dlc-profile.toml`;
+- the example validates as a personal layer and contains no personal account, organization, vault, repository, or credential value;
+- the machine example validates as a machine layer and demonstrates `LINEAR_SANDBOX_TOKEN` as a variable name only;
+- generated handbook pages mention portable profile, machine enrollment, secret ownership, local/cloud boundary, and the design→implementation workflow;
+- no template tells users to commit `.env` files or credential values.
+
+- [ ] **Step 2: Run template tests and confirm failure**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_templates.py -q
+```
+
+Expected: tests fail because the profile example and new handbook language are absent.
+
+- [ ] **Step 3: Add the public profile and machine examples**
+
+Create `profiles/example/ai-dlc-profile.toml` with profile ID `example-development`, conservative `core` and `python` modules, provider-neutral roles, an empty agent server collection, and a demonstrative `linear-sandbox` credential requirement. Do not include Sean's profile, workspace IDs, team IDs, account names, paths, remotes, or secret values.
+
+Extend `profiles/machines/example.toml` with a commented or inert credential binding using `source = "environment"` and `variable = "LINEAR_SANDBOX_TOKEN"`. Ensure the parsed file remains valid schema 4.
+
+- [ ] **Step 4: Update product and generated handbook documentation**
+
+Document:
+
+- the five ownership layers and their Git/sync policy;
+- creating a separate private profile repository with `ai-dlc-profile.toml`;
+- enrolling the same pinned profile on a second machine;
+- editing the machine binding independently on each machine;
+- using `machine status`, `plan`, `apply`, `sync`, and `doctor`;
+- storing Linear and future provider credentials in a password manager/keychain that injects the configured environment variable, never in AI-DLC Git files;
+- local execution as today's primary control plane and hosted/cloud execution as a later qualification target;
+- normal migration from `profiles/sean.toml`, including `machine migrate` and eventual reenrollment with the canonical filename;
+- provider-neutral knowledge ownership, with Obsidian create/attach and provider discovery explicitly identified as the next cycle rather than falsely documented as complete;
+- brownfield and greenfield design→implementation stages and which CLI/MCP/skill surface owns each stage.
+
+Update both source handbook pages and their project-template copies so generated repositories do not drift from the product guidance.
+
+- [ ] **Step 5: Verify and commit Task 9**
+
+Run:
+
+```sh
+uv run --locked --no-sync pytest tests/test_templates.py tests/test_config.py -q
+uv run --locked --no-sync python scripts/check_generated.py
+uv run --locked --no-sync ruff check tests/test_templates.py
+git diff --check
+```
+
+Expected: all commands pass.
+
+Commit only the example, documentation, template, and test files:
+
+```sh
+git add profiles/example/ai-dlc-profile.toml profiles/machines/example.toml README.md docs/architecture.md docs/development-workflow.md docs/workflows/tool-map.md docs/migration.md project-templates/project/AI-DLC.md project-templates/project/docs/development-workflow.md.jinja project-templates/project/docs/workflows/tool-map.md tests/test_templates.py
+git commit -m "docs: document portable machine enrollment"
+```
+
+---
+
+### Task 10: Dogfood the lifecycle, run release-grade verification, and prepare review
+
+**Files:**
+
+- Modify: `docs/release-verification.md`
+- Modify: `.ai-dlc/work/portable-profile-enrollment.toml`
+- Move: `openspec/changes/portable-profile-enrollment/` → `openspec/changes/archive/2026-09-03-portable-profile-enrollment/`
+- Create: `docs/reviews/2026-09-03-portable-profile-enrollment.md`
+
+- [ ] **Step 1: Validate and optionally publish the dogfood work record**
+
+Validate the reviewed work record created in Task 0. It is already bound to the active OpenSpec change, current `codex/portable-profile-enrollment` branch, and repository tracker/SCM providers. Do not add provider credentials or guessed Linear IDs.
+
+Run the existing record/status commands locally. If the already-designated `sandbox-aidlc` team and native status IDs are configured in ignored machine-local configuration, publish/start/link this record using the normal AI-DLC work commands. If those non-secret IDs are still absent, leave the record locally valid and state that provider publication is the one operator action deferred to the provider-onboarding cycle; do not access another Linear workspace and do not guess IDs.
+
+- [ ] **Step 2: Exercise the new lifecycle against a clean disposable profile repo**
+
+Create a temporary Git repository outside the checkout containing the public example as `ai-dlc-profile.toml`. Use temporary XDG roots and execute the installed source checkout:
+
+```sh
+AI_DLC_TEST_HOME="$(mktemp -d)"
+XDG_CONFIG_HOME="$AI_DLC_TEST_HOME/config" XDG_CACHE_HOME="$AI_DLC_TEST_HOME/cache" XDG_STATE_HOME="$AI_DLC_TEST_HOME/state" ai-dlc machine enroll "$AI_DLC_TEST_HOME/profile-repo" --profile-id example-development --machine-id verification-machine
+XDG_CONFIG_HOME="$AI_DLC_TEST_HOME/config" XDG_CACHE_HOME="$AI_DLC_TEST_HOME/cache" XDG_STATE_HOME="$AI_DLC_TEST_HOME/state" ai-dlc machine enroll "$AI_DLC_TEST_HOME/profile-repo" --profile-id example-development --machine-id verification-machine --apply
+XDG_CONFIG_HOME="$AI_DLC_TEST_HOME/config" XDG_CACHE_HOME="$AI_DLC_TEST_HOME/cache" XDG_STATE_HOME="$AI_DLC_TEST_HOME/state" ai-dlc machine status
+XDG_CONFIG_HOME="$AI_DLC_TEST_HOME/config" XDG_CACHE_HOME="$AI_DLC_TEST_HOME/cache" XDG_STATE_HOME="$AI_DLC_TEST_HOME/state" ai-dlc machine plan
+```
+
+Use a task-specific variable exactly as shown; do not use or overwrite `HOME`. Remove the temporary directory only after capturing the non-secret results. Do not run `machine apply` against the real user home during this verification.
+
+- [ ] **Step 3: Run focused security and packaging checks**
+
+Run:
+
+```sh
+uv build
+uv run --locked --no-sync pytest tests/test_credentials.py tests/test_enrollment.py tests/test_profile_source.py tests/test_machine.py tests/test_machine_integration.py -q
+uv run --locked --no-sync python scripts/check_generated.py
+```
+
+Inspect the built wheel and assert the example profile is included while `.ai-dlc/local`, enrollment locks, machine files, environment files, Git metadata, and user-specific paths are absent.
+
+- [ ] **Step 4: Run the repository's full required gate**
+
+Run:
+
+```sh
+ai-dlc project check --required --receipt .ai-dlc/local/portable-profile-enrollment-receipt.json
+```
+
+Expected: `generated`, `format`, `lint`, `types`, and `test` all pass. The receipt remains ignored under `.ai-dlc/local/` and must not be staged.
+
+If any check fails, invoke `superpowers:systematic-debugging`, reproduce the smallest failing command, add a regression test where appropriate, fix the root cause, and rerun the entire required gate.
+
+- [ ] **Step 5: Finalize the formal specification, record evidence, and perform an independent code review**
+
+Mark every completed item in `openspec/changes/portable-profile-enrollment/tasks.md`, validate the active change strictly, then move the complete directory to `openspec/changes/archive/2026-09-03-portable-profile-enrollment/`. Update the work record's `artifacts.spec` value to that exact archive path and validate the archive strictly.
+
+Update `docs/release-verification.md` with dated, factual evidence from the disposable enrollment and the full required gate. Do not claim clean-machine hosted/cloud qualification, provider onboarding, Obsidian attach/create, full Linear discovery, behavioral skill evaluation, or published release assets.
+
+Use `superpowers:requesting-code-review` to review the complete branch against the approved design and this plan. Save the resulting findings and resolutions in `docs/reviews/2026-09-03-portable-profile-enrollment.md`. Address every correctness, security, compatibility, or test-gap finding before continuing.
+
+- [ ] **Step 6: Verify no secret or unrelated file is staged**
+
+Run:
+
+```sh
+git status --short
+git diff --cached --name-only
+git grep -n "fake-value-that-must-not-escape" -- . ':!docs/superpowers/plans/2026-09-03-portable-profile-enrollment.md' ':!tests/test_credentials.py' ':!tests/test_machine_integration.py'
+git diff --check
+```
+
+Expected:
+
+- `.ai-dlc/local/linear.env` and `.ai-dlc/local/.linear.env.swp` are not staged or displayed;
+- `.DS_Store`, `.ai-dlc/.DS_Store`, and `target/.rustc_info.json` remain unrelated and unstaged;
+- no sentinel credential value appears outside the redaction test sources and this plan;
+- only the Task 10 work record, archived specification, verification doc, review report, and any review-driven source/test fixes are staged.
+
+- [ ] **Step 7: Commit verification evidence**
+
+Run:
+
+```sh
+git add .ai-dlc/work/portable-profile-enrollment.toml openspec/changes/portable-profile-enrollment openspec/changes/archive/2026-09-03-portable-profile-enrollment docs/release-verification.md docs/reviews/2026-09-03-portable-profile-enrollment.md
+git commit -m "test: verify portable profile enrollment"
+```
+
+If review-driven code changed after the previous commit, include only those reviewed source/test files after rerunning the full required gate.
+
+- [ ] **Step 8: Finish the branch using the integration workflow**
+
+Invoke `superpowers:verification-before-completion`, rerun its required evidence checks, then invoke `superpowers:finishing-a-development-branch`. The expected integration path is:
+
+1. push `codex/portable-profile-enrollment`;
+2. create a pull request describing motivation, functional changes, schema/template migration, before/after CLI surface, and remaining provider-onboarding/cloud/release work;
+3. wait for required CI;
+4. merge only when checks pass and review findings are resolved;
+5. update the main checkout with a fast-forward pull;
+6. verify the merged revision locally with `ai-dlc project check --required`;
+7. use `work finish` only if the sandbox work record was successfully published and its exact merged-revision CI evidence is available.
+
+Do not mark Linear work complete before the PR is merged and merged-revision CI receipts pass.

--- a/docs/superpowers/specs/2026-09-03-portable-profile-enrollment-design.md
+++ b/docs/superpowers/specs/2026-09-03-portable-profile-enrollment-design.md
@@ -1,0 +1,376 @@
+# Portable profile and machine enrollment design
+
+## Status
+
+Proposed design for the approved first AI-DLC dogfooding direction. This design
+turns the existing configuration and setup primitives into a reproducible
+enrollment flow. It is the first of five independently releasable cycles: profile
+enrollment, provider onboarding, agent/workflow portability, daily workflow
+usability, and release qualification.
+
+## Problem
+
+AI-DLC can install built-in modules, resolve explicitly supplied configuration
+layers, render MCP servers into supported agent clients, prepare projects, and
+verify work. It does not yet give a person one portable source that a new machine
+can enroll from and later reconcile.
+
+Today a user must remember which profile and machine files to pass, where those
+files belong, how to place AI-DLC on `PATH`, and how to repeat the setup on another
+machine. Environment variable names can be declared safely, but credential
+requirements have no logical identity and no enrollment-time validation. The
+result is a collection of sound primitives rather than the intended portable
+desired-state framework.
+
+## Outcome
+
+A user can keep a secret-free personal AI-DLC profile in a private or public Git
+repository, enroll a supported machine from a pinned revision, bind that machine's
+paths and credential environment names, preview the resulting changes, apply them,
+and later synchronize deliberately. Two enrolled machines resolve the same tools,
+MCP definitions, workflow selections, and provider preferences while retaining
+different local bindings and secret values.
+
+## Goals
+
+- Make a versioned profile bundle the portable source for personal tool, MCP,
+  workflow, and provider preferences.
+- Add a coherent `machine` command group for enrollment, planning, application,
+  synchronization, status, and readiness checks.
+- Discover enrolled personal and machine configuration automatically while
+  preserving explicit command-line overrides.
+- Give credentials stable logical names while keeping secret values in external
+  credential stores or the process environment.
+- Pin the resolved Git commit and content digest used by each machine.
+- Preserve plan-before-apply behavior, authored client configuration, and existing
+  v4 configuration compatibility.
+- Dogfood the resulting lifecycle in the AI-DLC repository.
+
+## Non-goals
+
+- AI-DLC will not store, synchronize, print, or back up secret values.
+- This cycle will not configure 1Password, macOS Keychain, or a cloud secret store.
+  Those systems inject environment variables through target-specific mechanisms.
+- This cycle will not configure Obsidian Sync or another file synchronization
+  service.
+- This cycle will not create or attach an Obsidian vault. Provider-neutral
+  knowledge onboarding is the next cycle and consumes the machine-binding model
+  defined here.
+- This cycle will not discover Linear teams or statuses or import existing Linear
+  work. Tracker onboarding is the next cycle.
+- This cycle will not permit arbitrary installation commands from an untrusted
+  profile. Profiles may select the verified built-in module catalog. Extensible
+  signed module and workflow packages belong to the agent/workflow portability
+  cycle.
+- This cycle will not create a hosted AI-DLC control plane.
+- This cycle will not claim cloud equivalence or release readiness.
+
+## Chosen approach
+
+Use a Git-backed declarative profile bundle plus local enrollment and machine
+bindings. This preserves local-first operation, makes changes reviewable, works
+offline from the last verified revision, and avoids a new hosted service.
+
+Rejected alternatives:
+
+1. Project-only configuration duplicates personal tools and MCP definitions across
+   repositories and mixes personal choices with team-owned policy.
+2. Copying generated Codex, Claude, shell, or tool files between machines loses
+   ownership and cannot adapt paths or client formats safely.
+3. A hosted settings service adds identity, availability, data ownership, and
+   security concerns before the local framework is complete.
+
+## Ownership model
+
+| Data | Owner | Portability |
+| --- | --- | --- |
+| Profile bundle | User-controlled Git repository | Shared across enrolled machines |
+| Project configuration | Project repository | Shared with project collaborators |
+| Enrollment lock | User-level AI-DLC configuration | Recreated per machine from the same source |
+| Machine bindings | User-level AI-DLC configuration | Local to one machine |
+| Credential values | External credential provider or process environment | Supplied independently on each target |
+| Generated client configuration | Codex or Claude user/project configuration | Re-rendered, never copied |
+| Operation and setup journals | User-level AI-DLC state | Local cache, never authoritative remotely |
+
+The initial personal profile should live outside the public AI-DLC product
+repository, normally in a private dotfiles or dedicated profile repository. It may
+be public when it contains no sensitive account names or organization metadata.
+
+## Profile bundle
+
+The source is a Git repository, optionally narrowed to a relative subdirectory,
+containing `ai-dlc-profile.toml`. The first schema reuses current schema-4 personal
+fields and adds a stable top-level profile identity:
+
+- selected built-in modules;
+- user preferences;
+- default provider roles;
+- selected shipped workflow skills;
+- user-level MCP server definitions containing environment variable names only.
+
+It also introduces logical credential requirements:
+
+```toml
+schema = 4
+profile_id = "sean-development"
+
+[credentials.linear-sandbox]
+description = "Linear API access for the AI-DLC sandbox"
+required_by = ["provider.linear-sandbox"]
+```
+
+Descriptions and dependency identifiers are portable. A field name associated
+with a credential must never accept its value in a profile.
+
+The enrollment lock records:
+
+```toml
+schema = 1
+profile_id = "sean-development"
+source = "git@github.com:example/ai-dlc-profile.git"
+requested_ref = "main"
+resolved_commit = "<40-character commit>"
+content_sha256 = "<bundle digest>"
+machine_id = "personal-macbook"
+subdirectory = ""
+profile_file = "ai-dlc-profile.toml"
+```
+
+The lock contains no Git credentials. Native Git authentication owns source
+access. A local Git checkout is allowed as the source for development but is
+reported as nonportable. The `--profile-id` enrollment argument must match the
+identity declared by `ai-dlc-profile.toml`; it is an explicit guard against
+enrolling the wrong bundle.
+
+## Machine bindings
+
+Machine bindings extend the existing schema-4 machine layer. A credential binding
+maps a logical credential to an environment variable name, never a value:
+
+```toml
+schema = 4
+
+[target]
+name = "local"
+
+[credentials.linear-sandbox]
+source = "environment"
+variable = "LINEAR_SANDBOX_TOKEN"
+
+[paths]
+vault = "/machine-specific/path/to/vault"
+```
+
+Only `source = "environment"` is implemented in this cycle. The schema leaves room
+for future target-specific credential resolvers without accepting arbitrary shell
+commands. Existing provider `token_env` settings remain supported and are normalized
+to the credential resolver internally.
+
+Machine IDs are explicit stable slugs. AI-DLC may suggest a sanitized hostname but
+must not silently use hardware identifiers or upload machine information.
+
+## Filesystem layout
+
+Use XDG locations with current macOS/Linux fallbacks:
+
+```text
+<config>/ai-dlc/enrollment.toml
+<config>/ai-dlc/machines/<machine-id>.toml
+<cache>/ai-dlc/profiles/<profile-id>/<resolved-commit>/
+<state>/ai-dlc/
+```
+
+`enrollment.toml` is the active profile lock. Machine binding files contain paths,
+account selections, and credential environment names but no secret values. Cached
+profile content is an immutable materialized tree without Git metadata, keyed by
+resolved commit. In this first cycle the materialized tree contains only the declared
+profile file; unrelated files from a larger dotfiles repository are never copied.
+State continues to contain setup and mutation journals.
+
+## Configuration resolution
+
+Configuration resolves in this order:
+
+1. packaged base defaults;
+2. enrolled personal profile;
+3. project `ai-dlc.toml`;
+4. enrolled machine binding.
+
+Higher scopes may override only fields allowed by the existing scope policy. Machine
+configuration cannot weaken project checks or change executable provider behavior.
+Every resolved value retains provenance.
+
+Explicit `--profile` and `--machine` flags remain available for tests, migrations,
+and one-off use. An explicit file replaces the enrolled file in that same scope; it
+does not become a new highest-precedence layer. Commands use the enrolled files by
+default when those flags are absent. Environment variables may point to alternate
+non-secret configuration files, but they do not contain inline configuration or
+credentials.
+
+## Command interface
+
+Add a `machine` command group:
+
+```text
+ai-dlc machine enroll <git-source> --profile-id <id> --machine-id <id> [--ref <ref>] [--subdirectory <path>] [--apply]
+ai-dlc machine migrate <git-source> --profile-file <path> --profile-id <id> --machine-id <id> [--ref <ref>] [--apply]
+ai-dlc machine plan
+ai-dlc machine apply
+ai-dlc machine sync [--apply]
+ai-dlc machine status
+ai-dlc machine doctor [--root <project>]
+```
+
+`enroll` and `sync` preview by default and require `--apply` to change the active
+lock. `machine plan` previews workstation and client changes; `machine apply` is the
+explicit mutation paired with that plan. Enrollment performs no package installation
+or client rewrite. Its plan shows the source, resolved commit, proposed lock,
+required machine bindings, missing credential variables, modules, MCP changes, and
+any ownership conflicts.
+
+`sync` fetches the requested ref, resolves it to a commit, verifies the bundle, and
+previews the difference from the current lock. With `--apply`, AI-DLC runs the same
+reconciler as `machine apply` against the verified candidate, then atomically updates
+the active lock only after reconciliation succeeds. The candidate cache may remain
+after a failure, but it is inactive and may be reused by a later attempt.
+
+`status` is read-only and reports profile identity, locked revision, cache health,
+machine binding, drift, and missing requirements. `doctor` combines machine status,
+project readiness, client rendering, native sign-ins, credential presence, and
+provider health without printing secret values.
+
+Existing `setup plan`, `setup apply`, `profile show`, and explicit `--machine`
+interfaces remain as compatibility entry points. They call the same resolver and
+reconciler; documentation moves to the `machine` vocabulary.
+
+## Service boundaries
+
+Implement focused units rather than adding more policy to the CLI module:
+
+- `profile_source`: resolve local/Git sources, pin commits, cache immutable content,
+  and compute bundle digests;
+- `enrollment`: validate and persist enrollment locks and machine identities;
+- `credentials`: resolve logical requirements to environment variable names and
+  report presence without exposing values;
+- `configuration`: discover enrolled layers and retain provenance;
+- `machine`: compose planning, setup, client rendering, and readiness services;
+- `cli`: parse arguments and serialize service results only.
+
+The MCP server does not expose enrollment mutations in this cycle. Machine setup is
+an explicit operator action. Read-only machine status may be exposed after the CLI
+contract stabilizes.
+
+## Enrollment flow
+
+```mermaid
+flowchart TD
+    S[Select profile Git source] --> R[Resolve requested ref to commit]
+    R --> V[Validate schema and secret-free content]
+    V --> P[Preview enrollment and missing bindings]
+    P --> B[Create or edit local machine bindings]
+    B --> A[Apply locked profile]
+    A --> T[Install selected tools]
+    T --> M[Render owned MCP and agent configuration]
+    M --> D[Run machine doctor]
+    D -->|Ready| U[Use projects]
+    D -->|Missing requirement| B
+```
+
+## Synchronization and offline behavior
+
+- An enrolled machine continues using its verified cached commit while offline.
+- A failed fetch does not invalidate the active profile.
+- A moved branch or tag produces a preview; it never updates the lock implicitly.
+- A missing or changed cached file fails integrity validation and requires a refetch.
+- Applying a new profile commit is transactional for AI-DLC-owned lock/cache metadata
+  and retains existing rollback behavior for generated client configuration.
+- Package managers remain responsible for their own partial installation behavior;
+  AI-DLC reports the failed step and resumes through the existing setup journal.
+
+## Error and conflict handling
+
+- Reject profile files containing secret-shaped value fields before any write.
+- Reject unsupported schema versions, unknown top-level fields, invalid machine IDs,
+  ambiguous Git revisions, and profile-ID changes without explicit reenrollment.
+- Reject a source revision that cannot be tied to an exact commit.
+- Preserve user-edited Codex, Claude, shell, and MCP configuration through current
+  ownership checks.
+- Preserve the active enrollment when a sync candidate is invalid or application
+  fails.
+- Report missing credentials by logical ID and environment variable name only.
+- Never include environment values in plans, errors, logs, receipts, or journals.
+- Treat a locally modified cached profile as corrupt rather than as an authored edit.
+
+## Migration
+
+`profiles/sean.toml` becomes the seed for a separate personal profile repository.
+The public repository retains `profiles/base.toml` and a nonpersonal example. The
+existing file remains accepted during one compatibility window but is no longer the
+recommended source.
+
+`machine migrate` enrolls an existing schema-4 personal file already stored in a Git
+source. Its explicit `--profile-file` path is recorded in the compatibility lock so
+later syncs remain deterministic. A legacy file may omit `profile_id`; the supplied
+ID becomes the guarded lock identity. The command previews the proposed lock and
+machine file and requires `--apply` to activate them. It never rewrites the source,
+moves credentials, or guesses a vault path. Reenrolling after renaming the source
+file to `ai-dlc-profile.toml` completes the migration.
+Existing `token_env` declarations continue working while documentation adopts logical
+credential IDs.
+
+The first AI-DLC work item uses a documented bootstrap exception: create the branch
+and configure the sandbox provider manually, then use AI-DLC publication, checks,
+linking, and finish. Once enrollment lands, later cycles must start through the
+AI-DLC work service.
+
+## Verification strategy
+
+Tests must establish behavior, not only file generation:
+
+1. Unit tests validate source URLs, refs, locks, bundle digests, machine IDs,
+   credential schemas, and secret rejection.
+2. Configuration tests prove automatic precedence and provenance while preventing
+   machine weakening of project policy.
+3. Source tests use temporary Git repositories to prove commit pinning, deliberate
+   sync, offline cache use, moved refs, corrupt cache rejection, and failed-fetch
+   rollback.
+4. Enrollment tests use two isolated home directories with different machine paths
+   and credential variable names. Both must resolve identical portable tools, MCP
+   definitions, workflow selections, and provider preferences.
+5. Integration tests prove plan has no writes, apply is idempotent, authored client
+   configuration survives, missing credentials remain redacted, and setup resumes.
+6. Compatibility tests retain current explicit profile/machine flags and setup
+   commands.
+7. Template tests ensure new projects explain enrollment without embedding a personal
+   source or secret.
+8. The repository's complete required check suite remains green.
+
+## Acceptance criteria
+
+- A fresh supported machine can enroll from an exact Git-backed profile revision
+  using one command and a reviewed apply step.
+- A second simulated machine obtains the same portable desired state with independent
+  paths and credential environment names.
+- A machine can operate offline from the last verified cached revision.
+- Profile synchronization never changes active state without `--apply`.
+- No profile, lock, machine file, generated configuration, output, journal, or test
+  fixture contains a credential value.
+- Existing authored agent configuration and current explicit CLI interfaces remain
+  intact.
+- `machine doctor` identifies every missing binding needed for the selected profile
+  and project.
+- The first dogfood work item is linked to the sandbox tracker, verified by required
+  checks, merged through GitHub, and completed through AI-DLC.
+
+## Follow-on cycles
+
+1. Provider onboarding adds provider-neutral connect/discover/test contracts,
+   Obsidian create/attach/status, Linear workspace/team/status discovery, and existing
+   tracker attachment.
+2. Agent and workflow portability adds pinned external module/workflow packages,
+   automatic AI-DLC MCP registration, hook activation, and behavioral evaluations.
+3. Daily workflow usability adds work initialization/import/review/reconciliation,
+   automatic artifact discovery, repository policy verification, and human-readable
+   output.
+4. Release qualification completes live conformance, clean target walkthroughs,
+   cloud equivalence, signed artifacts, installation, upgrade, and rollback evidence.

--- a/docs/workflows/tool-map.md
+++ b/docs/workflows/tool-map.md
@@ -16,7 +16,7 @@ vendor part of the lifecycle definition.
 | Review, merge, and CI identity | `scm` | GitHub | Branches, pull requests, merged SHA, workflow runs, and artifacts |
 | Deployment evidence | `deploy` | None by default | Environment-specific release evidence when configured |
 | Interactive agent | `agent-client` | Claude Code and Codex | Analysis, judgment, authoring, and tool use under user authorization |
-| Deterministic workflow | AI-DLC CLI/MCP services | Local Python implementation | Validation, rendering, bindings, reconciliation, receipts, and gates |
+| Deterministic workflow | AI-DLC CLI and selected MCP services | Local Python implementation | CLI: validation, rendering, machine bindings, reconciliation, receipts, and gates; MCP: reviewed work, doctor, and knowledge only |
 | Project generation and updates | Template service | Copier | Template answers, source revision, preview, and three-way updates |
 
 Projects may omit roles they do not need. Confirm the actual mapping in the
@@ -52,6 +52,29 @@ Skills provide judgment patterns. Provider instructions define vendor
 operations. AI-DLC services own validation and mutation boundaries. A skill
 cannot bypass completion gates or expand the user's authorization.
 
+## Portable enrollment boundary
+
+A private profile repository owns the portable `ai-dlc-profile.toml` and is
+enrolled by pinned revision. A second machine enrolls that same revision but
+maintains its own machine binding for paths, account selection, and
+environment-variable names. The project repository owns shared policy; an
+external password manager, keychain, or secret injector owns credential values
+and supplies them transiently through the process environment. Codex and Claude
+own their generated client configuration. Never commit `.env` files or
+credential values.
+
+`ai-dlc machine status`, `plan`, `apply`, `sync`, and `doctor` own the local
+enrollment lifecycle. Local CLI and MCP execution are current; hosted or cloud
+execution is a later qualification target. Obsidian create/attach and provider
+discovery are next-cycle gaps rather than current provider capabilities.
+
+Machine enrollment mutations are CLI-only in this cycle. MCP exposes exactly
+`work_publish`, `work_start`, `work_status`, `work_link`, `work_finish`,
+`doctor`, `knowledge_find`, `knowledge_append`, and `knowledge_note`; it does
+not expose machine enrollment mutation. These MCP identifiers differ from the
+space-separated CLI commands, such as `ai-dlc work publish` and `ai-dlc
+knowledge append`.
+
 ## Command and service map
 
 | Area | Interfaces | Effect |
@@ -67,7 +90,7 @@ cannot bypass completion gates or expand the user's authorization.
 | Personal knowledge | `ai-dlc knowledge find`, `ai-dlc knowledge note`, `ai-dlc knowledge append` | Reads or writes explicitly selected vault material |
 | Configuration profiles | `ai-dlc profile show`, `ai-dlc profile migrate`, `ai-dlc profile capture` | Resolves provenance, previews schema migration, or captures supported preferences |
 | Machine provisioning | `ai-dlc setup plan`, `ai-dlc setup apply` | Previews or applies selected workstation modules and personal agent configuration |
-| Agent-native access | `ai-dlc mcp serve` | Exposes the same workflow services and validation through local MCP |
+| Agent-native access | `ai-dlc mcp serve` | Exposes reviewed work, read-only doctor, and selected knowledge services through local MCP; machine enrollment mutation remains CLI-only |
 | Legacy compatibility | `ai-dlc scaffold` | Preserves the retired Rust-era provider scaffolding interface |
 
 ## Artifact ownership
@@ -94,8 +117,10 @@ flowchart TD
 - Knowledge provider: private continuity and links to durable artifacts.
 - Portable project configuration: provider roles and names of required
   environment variables, never their values.
-- Local machine scope and process environment: actual credential values,
-  account choices, paths, caches, and operation journals.
+- Local machine scope: account choices, paths, caches, journals, and ignored
+  non-secret control-plane IDs and metadata.
+- External password manager, keychain, or secret injector: actual credential
+  values, supplied transiently through the process environment.
 
 ## CI and release evidence
 

--- a/openspec/changes/archive/2026-09-03-portable-profile-enrollment/design.md
+++ b/openspec/changes/archive/2026-09-03-portable-profile-enrollment/design.md
@@ -1,0 +1,97 @@
+## Context
+
+This change implements the approved [portable profile and machine enrollment
+design](../../../../docs/superpowers/specs/2026-09-03-portable-profile-enrollment-design.md).
+It turns existing configuration and setup primitives into a local-first,
+reproducible enrollment workflow: a Git profile supplies shared desired state and
+each enrolled machine supplies only its local bindings.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enroll a secret-free profile from an exact Git revision and preserve that pinned
+  revision for offline use.
+- Let two machines share profile choices while using different paths and
+  credential environment-variable names.
+- Keep lifecycle changes preview-first and preserve the active enrollment when a
+  candidate, reconciliation, or source operation fails.
+- Retain current schema-4 configuration and explicit CLI entry points.
+
+**Non-Goals:**
+
+- Store, synchronize, print, or back up secret values.
+- Configure password managers, keychains, cloud secret stores, Obsidian Sync,
+  tracker discovery, arbitrary profile installation commands, or a hosted control
+  plane.
+- Claim cloud equivalence or release readiness from local or fixture verification.
+
+## Decisions
+
+### Ownership layers
+
+Five ownership layers remain distinct:
+
+1. A user-controlled Git profile bundle owns portable tool, MCP, workflow, and
+   provider preferences.
+2. The project repository owns shared project configuration and policy.
+3. The local machine binding owns paths, account selections, and credential
+   environment-variable names.
+4. External credential providers or the process environment own credential
+   values; AI-DLC only carries logical identifiers and variable names.
+5. Codex and Claude user/project configuration owns generated client files, which
+   AI-DLC re-renders through existing ownership protections rather than copying.
+
+Enrollment locks, profile caches, and operation journals are local AI-DLC control
+state: useful for recovery and inspection, never a portable source of authority.
+
+### Lock, cache, and transaction model
+
+The active enrollment lock records the profile identity, source, requested ref,
+resolved 40-character commit, content digest, machine ID, and selected relative
+profile path. Cached content is an immutable materialized profile file keyed by
+profile identity and resolved commit, without Git metadata or unrelated source
+files. Source resolution validates the profile and digest before cache activation.
+
+Enroll and sync create and validate a candidate first. They preview by default;
+with `--apply`, reconciliation runs against the verified candidate and the lock is
+atomically activated last. A failed fetch, validation, cache-integrity check, or
+reconciliation leaves the prior active lock byte-for-byte unchanged. The verified
+active cache remains usable offline.
+
+### Resolution, credentials, and boundaries
+
+Configuration precedence is fixed: packaged base, enrolled personal profile,
+project `ai-dlc.toml`, then enrolled machine binding. Explicit `--profile` and
+`--machine` files replace the enrolled file only in the matching layer; they do
+not add a higher-precedence scope. Provenance remains available for resolved
+values, and machine settings cannot weaken project policy.
+
+Profiles declare stable logical credential requirements; machine bindings map them
+only to `source = "environment"` and a variable name. Values are never accepted,
+persisted, logged, returned, or copied. Existing provider `token_env` settings are
+normalized for compatibility.
+
+The CLI remains a parser and result serializer. Focused services resolve profile
+sources, persist enrollment state, report credential presence, resolve
+configuration, and compose planning, setup, client rendering, and readiness. MCP
+does not expose enrollment mutation in this cycle; read-only status is deferred
+until the CLI contract settles.
+
+### Compatibility strategy
+
+The implementation preserves schema 4 for base, personal, project, and machine
+files; enrollment locks use schema 1. Existing `setup plan`, `setup apply`,
+`profile show`, `doctor`, and explicit `--machine` / `--profile` interfaces route
+through the compatible resolver and reconciler. `machine migrate` supports a
+temporary legacy personal profile path while canonical profiles use
+`ai-dlc-profile.toml` and declare `profile_id`.
+
+## Risks / Trade-offs
+
+Git sources and cache integrity add local complexity, but exact commits,
+digest-verified materialization, and preview-first activation make changes
+reviewable and safely recoverable. Package managers can still leave partial
+external installation effects; AI-DLC reports the failed step while protecting its
+own lock/cache metadata and existing client ownership rules. Live provider and
+clean-target verification remain explicit release gates.

--- a/openspec/changes/archive/2026-09-03-portable-profile-enrollment/proposal.md
+++ b/openspec/changes/archive/2026-09-03-portable-profile-enrollment/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+AI-DLC has sound configuration, setup, and rendering primitives, but a person
+cannot yet enroll a new machine from one portable, reviewable source of personal
+desired state. That leaves profile paths, machine-specific settings, and repeated
+setup as manual knowledge rather than a safe lifecycle.
+
+The approved [portable profile and machine enrollment design](../../../../docs/superpowers/specs/2026-09-03-portable-profile-enrollment-design.md)
+defines the first dogfooding cycle that closes this gap without adding a hosted
+control plane or bringing credentials into AI-DLC-managed files.
+
+## What Changes
+
+- Add a Git-backed, secret-free personal profile bundle with an identity and
+  logical credential requirements.
+- Enroll a profile at an exact Git commit, materialize a digest-verified local
+  cache, and bind it to machine-local paths and credential environment names.
+- Add preview-first machine enrollment, migration, planning, apply, sync, status,
+  and doctor operations.
+- Automatically resolve the enrolled personal and machine layers while preserving
+  existing explicit overrides and schema-4 interfaces.
+- Document a nonpersonal example, migration path, verification evidence, and
+  remaining provider, cloud, and release qualification work.
+
+## Capabilities
+
+### New Capabilities
+
+- `portable-profile-enrollment`: reproducible, secret-free personal profile
+  enrollment and deliberate per-machine reconciliation.
+
+## Impact
+
+The Python CLI and shared services gain profile-source, enrollment, credential,
+configuration, and machine lifecycle boundaries. Configuration and provisioning
+tests must establish cache integrity, transactional active-state preservation,
+two-machine portability, redaction, and compatibility. No runtime dependency,
+hosted service, provider credential, or remote state change is introduced by this
+change. Existing configuration, setup, profile, doctor, and explicit-file routes
+remain compatible dependencies of the new enrollment capability rather than a
+separately modified capability.

--- a/openspec/changes/archive/2026-09-03-portable-profile-enrollment/specs/portable-profile-enrollment/spec.md
+++ b/openspec/changes/archive/2026-09-03-portable-profile-enrollment/specs/portable-profile-enrollment/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Enroll a secret-free pinned personal profile
+
+The system SHALL resolve a personal profile from a Git source to an exact commit,
+validate its declared identity and secret-free content, and preview enrollment by
+default. It SHALL activate a machine-local enrollment lock only when explicitly
+applied.
+
+#### Scenario: Profile identity is enrolled deliberately
+
+- **WHEN** an operator enrolls a profile whose declared ID matches `--profile-id`
+- **THEN** the preview reports the requested ref, resolved commit, content digest,
+  proposed lock, required bindings, and missing credential variable names without
+  exposing credential values
+
+#### Scenario: Invalid candidate preserves active state
+
+- **WHEN** source resolution, validation, or reconciliation of a candidate fails
+- **THEN** the current active enrollment lock remains unchanged
+
+### Requirement: Separate portable and machine-local configuration
+
+The system SHALL resolve configuration in base, personal, project, then machine
+order. A profile supplies portable preferences and logical credential requirements;
+a machine binding supplies only its local paths and credential environment-variable
+names.
+
+#### Scenario: Two machines use one pinned profile
+
+- **WHEN** two isolated machines enroll the same resolved profile commit
+- **THEN** they resolve the same portable desired state while retaining distinct
+  machine bindings and credential variable names
+
+#### Scenario: Explicit paths retain their scope
+
+- **WHEN** an operator supplies an explicit personal or machine configuration file
+- **THEN** it replaces the enrolled file only in that matching scope and does not
+  become a new precedence layer
+
+### Requirement: Synchronize and operate safely from verified cache
+
+The system SHALL materialize only the declared profile file into a
+digest-verified local cache. Synchronization SHALL preview a moved source ref and
+require explicit apply before changing the active lock.
+
+#### Scenario: Offline operation uses verified cache
+
+- **WHEN** the source is unavailable and the active cached profile passes
+  integrity validation
+- **THEN** status and planning use that active cached revision without fetching
+
+#### Scenario: Sync is transactional
+
+- **WHEN** synchronization is applied to a new verified commit
+- **THEN** reconciliation completes before the new lock is atomically activated
+
+### Requirement: Preserve credential and interface compatibility boundaries
+
+The system SHALL not persist, return, log, or render credential values. It SHALL
+retain schema-4 configuration compatibility and existing setup, profile, doctor,
+and explicit machine interfaces while adding the machine lifecycle.
+
+#### Scenario: Credential readiness is redacted
+
+- **WHEN** status, planning, or doctor evaluates a credential requirement
+- **THEN** it reports only the logical ID, environment variable name, and presence
+  state, never the environment value
+
+#### Scenario: Existing explicit workflow remains available
+
+- **WHEN** an operator uses an existing setup, profile, doctor, or explicit
+  `--machine` entry point
+- **THEN** it continues to resolve through the compatible configuration and
+  reconciliation boundaries

--- a/openspec/changes/archive/2026-09-03-portable-profile-enrollment/tasks.md
+++ b/openspec/changes/archive/2026-09-03-portable-profile-enrollment/tasks.md
@@ -1,0 +1,42 @@
+Task 0 is the completed bootstrap record: it creates the reviewed work record and
+this OpenSpec change from the approved [detailed design](../../../../docs/superpowers/specs/2026-09-03-portable-profile-enrollment-design.md).
+
+## 1. Portable credential declarations and machine bindings
+
+- [x] Add schema-4 personal credential requirements and machine environment-name bindings, including redacted readiness reporting and legacy `token_env` normalization.
+
+## 2. Enrollment locks and XDG paths
+
+- [x] Model schema-1 enrollment locks, XDG-owned paths, validated machine IDs, and atomic lock/machine-file persistence.
+
+## 3. Verified Git profile cache
+
+- [x] Resolve local or Git sources to exact commits, validate secret-free profile content, and materialize an immutable digest-verified cache.
+
+## 4. Enrolled configuration resolution
+
+- [x] Discover enrolled personal and machine files automatically with base → personal → project → machine precedence and compatible explicit overrides.
+
+## 5. Preview-first enrollment services
+
+- [x] Implement enrollment, legacy migration, and read-only status with candidate previews, lock-last activation, and redacted readiness.
+
+## 6. Reconcile, sync, and diagnose
+
+- [x] Compose planning, apply, deliberate sync, and doctor services so candidate failure preserves the active lock and client ownership safeguards.
+
+## 7. Machine CLI lifecycle
+
+- [x] Add thin `machine` CLI commands and retain compatible setup, profile, doctor, and explicit path entry points.
+
+## 8. Portability and containment proof
+
+- [x] Prove two-machine isolation, offline cache use, transaction rollback, authored-client preservation, and absence of credential values end to end.
+
+## 9. Public example and durable guidance
+
+- [x] Ship a nonpersonal profile example and update product, migration, architecture, workflow, and generated-template guidance.
+
+## 10. Dogfood and release-grade review
+
+- [x] Validate the dogfood lifecycle, run required gates, record factual verification evidence, complete independent task reviews, and archive the completed change.

--- a/openspec/specs/portable-profile-enrollment/spec.md
+++ b/openspec/specs/portable-profile-enrollment/spec.md
@@ -1,0 +1,80 @@
+# portable-profile-enrollment Specification
+
+## Purpose
+Provide reproducible, secret-free personal profile enrollment and deliberate
+per-machine reconciliation.
+
+## Requirements
+### Requirement: Enroll a secret-free pinned personal profile
+
+The system SHALL resolve a personal profile from a Git source to an exact commit,
+validate its declared identity and secret-free content, and preview enrollment by
+default. It SHALL activate a machine-local enrollment lock only when explicitly
+applied.
+
+#### Scenario: Profile identity is enrolled deliberately
+
+- **WHEN** an operator enrolls a profile whose declared ID matches `--profile-id`
+- **THEN** the preview reports the requested ref, resolved commit, content digest,
+  proposed lock, required bindings, and missing credential variable names without
+  exposing credential values
+
+#### Scenario: Invalid candidate preserves active state
+
+- **WHEN** source resolution, validation, or reconciliation of a candidate fails
+- **THEN** the current active enrollment lock remains unchanged
+
+### Requirement: Separate portable and machine-local configuration
+
+The system SHALL resolve configuration in base, personal, project, then machine
+order. A profile supplies portable preferences and logical credential requirements;
+a machine binding supplies only its local paths and credential environment-variable
+names.
+
+#### Scenario: Two machines use one pinned profile
+
+- **WHEN** two isolated machines enroll the same resolved profile commit
+- **THEN** they resolve the same portable desired state while retaining distinct
+  machine bindings and credential variable names
+
+#### Scenario: Explicit paths retain their scope
+
+- **WHEN** an operator supplies an explicit personal or machine configuration file
+- **THEN** it replaces the enrolled file only in that matching scope and does not
+  become a new precedence layer
+
+### Requirement: Synchronize and operate safely from verified cache
+
+The system SHALL materialize only the declared profile file into a
+digest-verified local cache. Synchronization SHALL preview a moved source ref and
+require explicit apply before changing the active lock.
+
+#### Scenario: Offline operation uses verified cache
+
+- **WHEN** the source is unavailable and the active cached profile passes
+  integrity validation
+- **THEN** status and planning use that active cached revision without fetching
+
+#### Scenario: Sync is transactional
+
+- **WHEN** synchronization is applied to a new verified commit
+- **THEN** reconciliation completes before the new lock is atomically activated
+
+### Requirement: Preserve credential and interface compatibility boundaries
+
+The system SHALL not persist, return, log, or render credential values. It SHALL
+retain schema-4 configuration compatibility and existing setup, profile, doctor,
+and explicit machine interfaces while adding the machine lifecycle.
+
+#### Scenario: Credential readiness is redacted
+
+- **WHEN** status, planning, or doctor evaluates a credential requirement
+- **THEN** it reports only the logical ID, environment variable name, and presence
+  state, never the environment value
+
+#### Scenario: Existing explicit workflow remains available
+
+- **WHEN** an operator uses an existing setup, profile, doctor, or explicit
+  `--machine` entry point
+- **THEN** it continues to resolve through the compatible configuration and
+  reconciliation boundaries

--- a/profiles/example/ai-dlc-profile.toml
+++ b/profiles/example/ai-dlc-profile.toml
@@ -1,0 +1,20 @@
+schema = 4
+profile_id = "example-development"
+
+[modules]
+include = ["core", "python"]
+
+[roles]
+specs = "openspec"
+tracker = "linear"
+knowledge = "obsidian"
+scm = "github"
+deploy = "none"
+agent-client = ["claude-code", "codex"]
+
+[agents]
+servers = []
+
+[credentials.linear-sandbox]
+description = "Credential for a sandbox tracker integration"
+required_by = ["provider.linear"]

--- a/profiles/machines/example.toml
+++ b/profiles/machines/example.toml
@@ -1,12 +1,17 @@
 schema = 4
 
 [paths]
-# Supply your existing vault location. This file deliberately has no guessed personal path.
-# vault = "/absolute/path/to/existing/vault"
+# Add machine-specific settings only after selecting a local configuration.
 
 [target]
 name = "local"
 headless = false
 
 [providers.linear]
-token_env = "LINEAR_API_KEY"
+token_env = "LINEAR_SANDBOX_TOKEN"
+
+# Bind this logical profile requirement independently on each enrolled machine.
+# This is an environment-variable name, not a credential value.
+[credentials.linear-sandbox]
+source = "environment"
+variable = "LINEAR_SANDBOX_TOKEN"

--- a/project-templates/project/.gitignore
+++ b/project-templates/project/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 node_modules/
 target/
 .ai-dlc/receipts/
+.ai-dlc/local/

--- a/project-templates/project/AI-DLC.md
+++ b/project-templates/project/AI-DLC.md
@@ -4,6 +4,15 @@ The repository owns durable architecture, product rationale, decisions, and runb
 
 Start with the [Development workflow](docs/development-workflow.md). It links the greenfield and brownfield paths, the design-to-implementation contract, and the current role-to-tool map.
 
+Portable personal profiles belong in a separate private Git repository and are
+enrolled at a pinned revision. Each machine maintains its own binding for local
+paths, account selection, and credential environment-variable names. Keep
+credential values in a password manager, keychain, or process environment;
+never commit `.env` files or values to AI-DLC Git files. Local CLI and MCP
+execution are current; hosted or cloud execution remains a later qualification
+target. MCP exposes reviewed work, doctor, and selected knowledge services;
+machine enrollment mutation remains CLI-only.
+
 Select scm.repository and provider account/environment references before external operations. Every preset checks generated agent files. New-project initialization also creates a minimal language app and requires its syntax/compiler check; first setup creates its lockfile and later setup is locked. Adoption leaves existing application manifests/source untouched and requires existing language lockfiles. Add acceptance tests and further required check IDs as behavior develops.
 
 This development template needs the AI-DLC release bootstrap artifacts before CI can run. The template includes reviewed scripts/bootstrap.sh and bootstrap prerequisite pins; supply bootstrap/release.sh and the corresponding locked artifact manifest from a published AI-DLC release. Verify the release integrity; do not download an unpinned latest script. No public release location is assumed.

--- a/project-templates/project/docs/development-workflow.md.jinja
+++ b/project-templates/project/docs/development-workflow.md.jinja
@@ -2,7 +2,8 @@
 
 This is the project entry point for the AI-DLC lifecycle. It describes stable
 stages; the [tool map](workflows/tool-map.md) shows which configured provider or
-service currently performs each role.
+service currently performs each role. The CLI owns lifecycle mutation; MCP
+exposes only its reviewed work, doctor, and knowledge services.
 
 - [Greenfield development](workflows/greenfield.md)
 - [Brownfield development](workflows/brownfield.md)
@@ -46,8 +47,57 @@ flowchart TD
 - Personal knowledge owns private continuity and links; it is not a repository
   mirror.
 - Portable configuration may name required environment variables but never
-  contains their secret values. Machine scope and the process environment own
-  actual credentials, account choices, paths, caches, and local journals.
+  contains their secret values. Machine configuration owns account choices and
+  local paths. `.ai-dlc/local/` may hold ignored non-secret control-plane IDs
+  and local metadata. Actual credential values stay in an OS keychain, password
+  manager, or secret injector and enter only the process environment.
+
+## Design to implementation ownership
+
+For both greenfield and brownfield work, skills own discovery, requirements,
+design judgment, and the specification decision. The CLI owns reviewed work
+records, local checks, machine lifecycle commands, and completion gates. Local
+MCP exposes reviewed work operations, read-only doctor inspection, and selected
+knowledge operations; machine enrollment mutations are CLI-only in this cycle.
+It does not create a second workflow. The design-to-implementation handoff is complete only when the
+approved design, any required specification, and the reviewed work record let
+implementation proceed without inventing behavior.
+
+## Portable profile and machine enrollment
+
+Keep a personal `ai-dlc-profile.toml` in a separate private Git repository and
+pin the revision enrolled on each machine. The profile owns portable modules,
+logical credential requirements, and agent preferences; the project repository
+owns shared policy and durable docs. Each machine independently owns its
+binding, including paths, account selection, and environment-variable names.
+Credential values belong only to a password manager, keychain, or process
+environment. Generated Codex and Claude client files remain owned by their
+client configuration, which AI-DLC updates through its ownership rules.
+
+Use `ai-dlc machine status`, `plan`, `apply`, `sync`, and `doctor` to inspect,
+preview, reconcile, update, and diagnose local enrollment. Local CLI and MCP
+execution are the current control plane; hosted or cloud execution is a later
+qualification target. Obsidian create/attach and provider discovery are
+next-cycle gaps, so knowledge remains provider-neutral and is attached only to
+an explicitly selected existing store.
+
+Preview a private profile enrollment can materialize an inactive cache, but it
+does not change active enrollment, client configuration, or package state.
+Repeat the same command with `--apply` to activate it:
+
+```sh
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG
+ai-dlc machine enroll SOURCE --profile-id example-development --machine-id MACHINE_A --ref IMMUTABLE_REF_OR_TAG --apply
+```
+
+The lock always records the exact resolved commit. An immutable advertised tag
+or ref gives cross-machine reproducibility, and `ai-dlc machine sync` is
+idempotent for it. An intentionally movable advertised branch instead enables
+`ai-dlc machine sync` to preview a candidate and `ai-dlc machine sync --apply`
+to activate it after validation and reconciliation. To move from one immutable
+tag to another, reenroll with the new ref. Enroll a second machine with the
+same advertised ref under the selected policy and a different machine ID; its
+local binding remains independent.
 
 ## Capability boundaries
 

--- a/project-templates/project/docs/workflows/tool-map.md
+++ b/project-templates/project/docs/workflows/tool-map.md
@@ -14,7 +14,7 @@ not configured provider choices.
 | Review and merge | `scm` | GitHub | Branch, PR, merged SHA, CI runs, and artifacts |
 | Deployment evidence | `deploy` | None | Environment evidence when configured |
 | Interactive agent | `agent-client` | Claude Code and Codex | Analysis, authoring, and authorized tool use |
-| Workflow enforcement | AI-DLC CLI/MCP | Local services | Validation, bindings, reconciliation, receipts, and gates |
+| Workflow enforcement | AI-DLC CLI and selected MCP services | Local services | CLI: validation, machine bindings, reconciliation, receipts, and gates; MCP: reviewed work, doctor, and knowledge only |
 | Project lifecycle | Copier | Template service | Answers, source revision, preview, and three-way updates |
 
 The complete publish/start/status/finish lifecycle requires configured tracker
@@ -45,6 +45,29 @@ Skills provide judgment. Provider instructions define vendor operations.
 AI-DLC services own validation and mutation boundaries; no skill bypasses finish
 gates or extends user authorization.
 
+## Portable enrollment boundary
+
+A private profile repository owns the portable `ai-dlc-profile.toml` and is
+enrolled by pinned revision. A second machine enrolls that same revision but
+maintains its own machine binding for paths, account selection, and
+environment-variable names. The project repository owns shared policy; an
+external password manager, keychain, or secret injector owns credential values
+and supplies them transiently through the process environment. Codex and Claude
+own their generated client configuration. Never commit `.env` files or
+credential values.
+
+`ai-dlc machine status`, `plan`, `apply`, `sync`, and `doctor` own the local
+enrollment lifecycle. Local CLI and MCP execution are current; hosted or cloud
+execution is a later qualification target. Obsidian create/attach and provider
+discovery are next-cycle gaps rather than current provider capabilities.
+
+Machine enrollment mutations are CLI-only in this cycle. MCP exposes exactly
+`work_publish`, `work_start`, `work_status`, `work_link`, `work_finish`,
+`doctor`, `knowledge_find`, `knowledge_append`, and `knowledge_note`; it does
+not expose machine enrollment mutation. These MCP identifiers differ from the
+space-separated CLI commands, such as `ai-dlc work publish` and `ai-dlc
+knowledge append`.
+
 ## Command groups
 
 | Area | Interfaces |
@@ -56,12 +79,12 @@ gates or extends user authorization.
 | Provider verification | `ai-dlc provider list`, `ai-dlc provider test` |
 | Personal knowledge | `ai-dlc knowledge find`, `ai-dlc knowledge note`, `ai-dlc knowledge append` |
 | Profiles and machine setup | `ai-dlc profile show`, `ai-dlc profile migrate`, `ai-dlc profile capture`; `ai-dlc setup plan`, `ai-dlc setup apply` |
-| Agent-native access | `ai-dlc mcp serve` |
+| Agent-native access | `ai-dlc mcp serve` — reviewed work, read-only doctor, and selected knowledge services; machine enrollment mutation remains CLI-only |
 | Legacy compatibility | `ai-dlc scaffold` |
 
-The local MCP server calls the same services and validation as the CLI. The
-legacy scaffold command preserves the retired Rust-era provider interface; it
-is not the project lifecycle.
+The local MCP server exposes only the reviewed services listed above; machine
+enrollment mutation remains CLI-only. The legacy scaffold command preserves the
+retired Rust-era provider interface; it is not the project lifecycle.
 
 When replacing a tool, keep its responsibility stable where possible. Update
 configuration, provider contracts, this map, relevant skills, integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ packages = ["src/ai_dlc"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "templates" = "ai_dlc/assets/legacy"
-"profiles" = "ai_dlc/assets/profiles"
+"profiles/base.toml" = "ai_dlc/assets/profiles/base.toml"
+"profiles/example/ai-dlc-profile.toml" = "ai_dlc/assets/profiles/example/ai-dlc-profile.toml"
+"profiles/machines/example.toml" = "ai_dlc/assets/profiles/machines/example.toml"
 "modules" = "ai_dlc/assets/modules"
 "agents" = "ai_dlc/assets/agents"
 "project-templates" = "ai_dlc/assets/project-templates"
@@ -32,6 +34,9 @@ packages = ["src/ai_dlc"]
 "targets" = "ai_dlc/assets/targets"
 "playbook" = "ai_dlc/assets/playbook"
 "bootstrap" = "ai_dlc/assets/bootstrap"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["/profiles/sean.toml"]
 
 [tool.ruff]
 target-version = "py312"

--- a/src/ai_dlc/cli.py
+++ b/src/ai_dlc/cli.py
@@ -9,7 +9,8 @@ from typing import Annotated
 
 import typer
 
-from ai_dlc.config import load_project, read_toml, resolve_files
+from ai_dlc.config import load_project, read_toml, resolve_files, resolve_runtime
+from ai_dlc.machine import MachineManager
 
 app = typer.Typer(no_args_is_help=True, help="Portable development for people and agents.")
 project = typer.Typer(no_args_is_help=True)
@@ -17,6 +18,7 @@ work = typer.Typer(no_args_is_help=True)
 agents = typer.Typer(no_args_is_help=True)
 profile = typer.Typer(no_args_is_help=True)
 setup = typer.Typer(no_args_is_help=True)
+machine = typer.Typer(no_args_is_help=True)
 knowledge = typer.Typer(no_args_is_help=True)
 provider = typer.Typer(no_args_is_help=True)
 mcp = typer.Typer(no_args_is_help=True)
@@ -26,6 +28,7 @@ for name, group in [
     ("agents", agents),
     ("profile", profile),
     ("setup", setup),
+    ("machine", machine),
     ("knowledge", knowledge),
     ("provider", provider),
     ("mcp", mcp),
@@ -38,7 +41,7 @@ def emit(value):
 
 
 def config_for(root: Path, machine: Path | None = None) -> dict:
-    return resolve_files(project=root / "ai-dlc.toml", machine=machine).values
+    return resolve_runtime(root, machine=machine).values
 
 
 @app.command()
@@ -192,7 +195,7 @@ def profile_show(
     machine: Path | None = None,
     resolved: bool = True,
 ):
-    result = resolve_files(base, personal, project, machine)
+    result = resolve_runtime(base=base, personal=personal, project=project, machine=machine)
     emit({"values": result.values, "sources": result.sources})
 
 
@@ -212,31 +215,105 @@ def profile_capture(profile: Path):
 
 @setup.command("plan")
 def setup_plan(
-    profile: Annotated[Path, typer.Option("--profile")],
+    profile: Annotated[Path | None, typer.Option("--profile")] = None,
     headless: bool = False,
     home: Path | None = None,
 ):
-    from ai_dlc.provision import machine_plan
-
-    emit(machine_plan(profile, headless=headless, home=home))
+    emit(MachineManager(home=home).plan(headless=headless, profile=profile))
 
 
 @setup.command("apply")
 def setup_apply(
-    profile: Annotated[Path, typer.Option("--profile")],
+    profile: Annotated[Path | None, typer.Option("--profile")] = None,
     headless: bool = False,
     home: Path | None = None,
 ):
-    from ai_dlc.provision import machine_apply
+    emit(MachineManager(home=home).apply(headless=headless, profile=profile))
 
-    emit(machine_apply(profile, headless=headless, home=home))
+
+@machine.command("enroll")
+def machine_enroll(
+    source: str,
+    profile_id: Annotated[str, typer.Option("--profile-id")],
+    machine_id: Annotated[str, typer.Option("--machine-id")],
+    ref: Annotated[str, typer.Option("--ref")] = "main",
+    subdirectory: Annotated[str, typer.Option("--subdirectory")] = "",
+    apply: bool = False,
+):
+    emit(
+        MachineManager().enroll(
+            source,
+            profile_id,
+            machine_id,
+            requested_ref=ref,
+            subdirectory=subdirectory,
+            apply=apply,
+        )
+    )
+
+
+@machine.command("migrate")
+def machine_migrate(
+    source: str,
+    profile_file: Annotated[str, typer.Option("--profile-file")],
+    profile_id: Annotated[str, typer.Option("--profile-id")],
+    machine_id: Annotated[str, typer.Option("--machine-id")],
+    ref: Annotated[str, typer.Option("--ref")] = "main",
+    subdirectory: Annotated[str, typer.Option("--subdirectory")] = "",
+    apply: bool = False,
+):
+    emit(
+        MachineManager().migrate(
+            source,
+            profile_file,
+            profile_id,
+            machine_id,
+            requested_ref=ref,
+            subdirectory=subdirectory,
+            apply=apply,
+        )
+    )
+
+
+@machine.command("plan")
+def machine_plan_command(headless: bool = False):
+    emit(MachineManager().plan(headless=headless))
+
+
+@machine.command("apply")
+def machine_apply_command(headless: bool = False):
+    emit(MachineManager().apply(headless=headless))
+
+
+@machine.command("sync")
+def machine_sync(apply: bool = False, headless: bool = False):
+    emit(MachineManager().sync(apply=apply, headless=headless))
+
+
+@machine.command("status")
+def machine_status():
+    emit(MachineManager().status())
+
+
+@machine.command("doctor")
+def machine_doctor(
+    root: Annotated[Path, typer.Option("--root")] = Path("."), target: str = "local"
+):
+    result = MachineManager().doctor(root, target=target)
+    emit(result)
+    if not result["ready"]:
+        raise typer.Exit(1)
 
 
 @app.command()
-def doctor(root: Path = Path("."), target: str = "local", machine: Path | None = None):
-    from ai_dlc.provision import doctor as run
-
-    result = run(root, target, machine)
+def doctor(
+    root: Annotated[Path | None, typer.Argument()] = None,
+    root_option: Annotated[Path, typer.Option("--root")] = Path("."),
+    target: str = "local",
+    machine: Path | None = None,
+):
+    selected_root = root or root_option
+    result = MachineManager().doctor(selected_root, target=target, machine=machine)
     emit(result)
     if not result["ready"]:
         raise typer.Exit(1)

--- a/src/ai_dlc/config.py
+++ b/src/ai_dlc/config.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 import tomllib
+from collections.abc import Mapping
 from dataclasses import dataclass
+from itertools import pairwise
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ai_dlc.enrollment import EnrollmentPaths
 
 SCHEMA = 4
 SCOPES = {
@@ -29,6 +35,31 @@ SCOPES = {
     "target": {"machine"},
     "project": {"base", "project"},
     "contracts": {"base", "project"},
+    "profile_id": {"personal"},
+    "credentials": {"personal", "machine"},
+}
+
+_CREDENTIAL_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_ENVIRONMENT_VARIABLE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_SENSITIVE_FIELD_TOKENS = {"token", "password", "passwd", "secret"}
+_SENSITIVE_FIELD_PAIRS = {
+    ("api", "key"),
+    ("access", "key"),
+    ("client", "key"),
+    ("private", "key"),
+}
+_SENSITIVE_COMPACT_FIELDS = {
+    "apikey",
+    "apitoken",
+    "accesskey",
+    "accesstoken",
+    "clientkey",
+    "clientsecret",
+    "privatekey",
+}
+_BENIGN_INTEGER_TOKEN_FIELDS = {
+    ("max", "token"),
+    ("token", "count"),
 }
 
 
@@ -48,6 +79,82 @@ def read_toml(path: Path) -> dict[str, Any]:
     return tomllib.loads(path.read_text())
 
 
+def _field_tokens(field: str) -> tuple[str, ...]:
+    separated = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field)
+    separated = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", separated)
+    tokens = [token.lower() for token in re.split(r"[^A-Za-z0-9]+", separated) if token]
+    singular = {
+        "tokens": "token",
+        "passwords": "password",
+        "secrets": "secret",
+        "keys": "key",
+    }
+    return tuple(singular.get(token, token) for token in tokens)
+
+
+def _is_sensitive_field(tokens: tuple[str, ...]) -> bool:
+    if _SENSITIVE_FIELD_TOKENS.intersection(tokens):
+        return True
+    if "".join(tokens) in _SENSITIVE_COMPACT_FIELDS:
+        return True
+    adjacent = set(pairwise(tokens))
+    return bool(_SENSITIVE_FIELD_PAIRS.intersection(adjacent))
+
+
+def _is_environment_reference(tokens: tuple[str, ...], value: Any) -> bool:
+    suffix_length = 2 if tokens[-2:] == ("env", "var") else 1 if tokens[-1:] == ("env",) else 0
+    return bool(
+        suffix_length
+        and _is_sensitive_field(tokens[:-suffix_length])
+        and isinstance(value, str)
+        and _ENVIRONMENT_VARIABLE.fullmatch(value)
+    )
+
+
+def _is_benign_integer_token_field(tokens: tuple[str, ...], value: Any) -> bool:
+    return tokens in _BENIGN_INTEGER_TOKEN_FIELDS and type(value) is int
+
+
+def _validate_credentials(layer: str, value: Any) -> None:
+    if not isinstance(value, dict):
+        raise TypeError(f"{layer}: credentials must be a table")
+    for credential_id, entry in value.items():
+        if not isinstance(credential_id, str) or not _CREDENTIAL_ID.fullmatch(credential_id):
+            raise ValueError(f"{layer}: credential ID must be a stable slug: {credential_id!r}")
+        if not isinstance(entry, dict):
+            raise TypeError(f"{layer}: credentials.{credential_id} must be a table")
+        if layer == "personal":
+            if "source" in entry or "variable" in entry:
+                invalid = "source" if "source" in entry else "variable"
+                raise ValueError(f"personal: cannot set credentials.{credential_id}.{invalid}")
+            if not isinstance(entry.get("description"), str):
+                raise ValueError(
+                    f"personal: credentials.{credential_id}.description must be a string"
+                )
+            required_by = entry.get("required_by")
+            if not isinstance(required_by, list) or not all(
+                isinstance(provider, str) for provider in required_by
+            ):
+                raise ValueError(
+                    f"personal: credentials.{credential_id}.required_by must be a string list"
+                )
+        elif layer == "machine":
+            if set(entry) != {"source", "variable"}:
+                invalid = next((key for key in entry if key not in {"source", "variable"}), None)
+                if invalid is not None:
+                    raise ValueError(f"machine: cannot set credentials.{credential_id}.{invalid}")
+                raise ValueError(
+                    f"machine: credentials.{credential_id} must contain source and variable"
+                )
+            if entry.get("source") != "environment":
+                raise ValueError(f"machine: credentials.{credential_id}.source must be environment")
+            variable = entry.get("variable")
+            if not isinstance(variable, str) or not _ENVIRONMENT_VARIABLE.fullmatch(variable):
+                raise ValueError(
+                    f"machine: credentials.{credential_id}.variable must be an environment variable"
+                )
+
+
 def _validate(layer: str, data: dict[str, Any]) -> None:
     if layer not in {"base", "personal", "project", "machine"}:
         raise ValueError(f"unknown layer: {layer}")
@@ -58,17 +165,16 @@ def _validate(layer: str, data: dict[str, Any]) -> None:
             raise ValueError(f"{layer}: unknown field {field}")
         if layer not in SCOPES[field]:
             raise ValueError(f"{layer}: cannot set {field}")
-    # Machine overrides may select credentials/accounts, never executable provider behavior.
-    if layer == "machine":
-        for name, settings in data.get("providers", {}).items():
-            for key in settings:
-                if key not in {"account", "token_env", "vault_path", "sandbox_workspace"}:
-                    raise ValueError(f"machine: cannot set providers.{name}.{key}")
 
     def secrets(value: Any, path: str = "") -> None:
         if isinstance(value, dict):
             for key, child in value.items():
-                if key.lower() in {"token", "password", "secret", "api_key", "access_token"}:
+                tokens = _field_tokens(key)
+                if (
+                    _is_sensitive_field(tokens)
+                    and not _is_environment_reference(tokens, child)
+                    and not _is_benign_integer_token_field(tokens, child)
+                ):
                     raise ValueError(
                         f"{layer}: credential value prohibited at {path}{key}; use environment reference"
                     )
@@ -78,6 +184,14 @@ def _validate(layer: str, data: dict[str, Any]) -> None:
                 secrets(child, path)
 
     secrets(data)
+    if "credentials" in data:
+        _validate_credentials(layer, data["credentials"])
+    # Machine overrides may select credentials/accounts, never executable provider behavior.
+    if layer == "machine":
+        for name, settings in data.get("providers", {}).items():
+            for key in settings:
+                if key not in {"account", "token_env", "vault_path", "sandbox_workspace"}:
+                    raise ValueError(f"machine: cannot set providers.{name}.{key}")
 
 
 def resolve_layers(layers: list[tuple[str, dict[str, Any]]]) -> Resolved:
@@ -169,4 +283,42 @@ def resolve_files(
             ]
             if path
         ]
+    )
+
+
+def resolve_runtime(
+    root: Path | None = None,
+    *,
+    base: Path | None = None,
+    personal: Path | None = None,
+    project: Path | None = None,
+    machine: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    enrollment_paths: EnrollmentPaths | None = None,
+) -> Resolved:
+    """Resolve the packaged base plus any active, verified enrollment layers."""
+    from ai_dlc.enrollment import EnrollmentPaths, read_lock
+    from ai_dlc.files import assets
+    from ai_dlc.profile_source import verify_cached_profile
+
+    paths = enrollment_paths or EnrollmentPaths.from_environment(home=home, environ=environ)
+    enrolled_personal: Path | None = None
+    enrolled_machine: Path | None = None
+    if personal is None or machine is None:
+        lock = read_lock(paths)
+        if lock is not None:
+            if personal is None:
+                enrolled_personal = verify_cached_profile(lock, paths)
+            if machine is None:
+                enrolled_machine = paths.machine_file(lock.machine_id)
+
+    project_file = project
+    if project_file is None and root is not None and (root / "ai-dlc.toml").exists():
+        project_file = root / "ai-dlc.toml"
+    return resolve_files(
+        base=base or assets("profiles") / "base.toml",
+        personal=personal or enrolled_personal,
+        project=project_file,
+        machine=machine or enrolled_machine,
     )

--- a/src/ai_dlc/credentials.py
+++ b/src/ai_dlc/credentials.py
@@ -1,0 +1,71 @@
+"""Credential requirement readiness without exposing credential values."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def _status_entry(
+    credential_id: str, entry: Mapping[str, Any], environ: Mapping[str, str]
+) -> dict[str, object]:
+    source = entry.get("source")
+    variable = entry.get("variable")
+    configured = source == "environment" and isinstance(variable, str)
+    present = bool(environ.get(variable)) if configured and isinstance(variable, str) else False
+    result: dict[str, object] = {
+        "id": credential_id,
+        "description": entry.get("description", ""),
+        "required_by": entry.get("required_by", []),
+        "configured": configured,
+        "present": present,
+    }
+    if configured:
+        result["source"] = source
+        result["variable"] = variable
+    return result
+
+
+def credential_status(
+    config: dict[str, Any],
+    environ: Mapping[str, str] | None = None,
+) -> list[dict[str, object]]:
+    """Return credential readiness metadata without returning credential values."""
+    environment = os.environ if environ is None else environ
+    credentials = config.get("credentials", {})
+    entries: dict[str, Mapping[str, Any]] = {
+        credential_id: entry
+        for credential_id, entry in credentials.items()
+        if isinstance(credential_id, str) and isinstance(entry, Mapping)
+    }
+    covered_provider_variables = {
+        (provider, entry.get("variable"))
+        for entry in entries.values()
+        for provider in entry.get("required_by", [])
+        if isinstance(provider, str) and isinstance(entry.get("variable"), str)
+    }
+    providers = config.get("providers", {})
+    if isinstance(providers, Mapping):
+        for provider_id, provider in providers.items():
+            if not isinstance(provider_id, str) or not isinstance(provider, Mapping):
+                continue
+            required_by = f"provider.{provider_id}"
+            token_env = provider.get("token_env")
+            kind = provider.get("kind", provider.get("type", provider_id))
+            if token_env is None and kind == "linear":
+                token_env = "LINEAR_API_KEY"
+            if (
+                isinstance(token_env, str)
+                and (required_by, token_env) not in covered_provider_variables
+            ):
+                entries[required_by] = {
+                    "description": f"Credential for provider {provider_id}",
+                    "required_by": [required_by],
+                    "source": "environment",
+                    "variable": token_env,
+                }
+    return [
+        _status_entry(credential_id, entries[credential_id], environment)
+        for credential_id in sorted(entries)
+    ]

--- a/src/ai_dlc/enrollment.py
+++ b/src/ai_dlc/enrollment.py
@@ -1,0 +1,153 @@
+"""Validated, machine-local enrollment metadata and XDG paths."""
+
+import os
+import re
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+import tomli_w
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ai_dlc.files import atomic_create, atomic_write
+
+_STABLE_ID = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _stable_id(value: str, field: str) -> str:
+    if not _STABLE_ID.fullmatch(value):
+        raise ValueError(f"{field} must be a stable lowercase ID")
+    return value
+
+
+def _commit(value: str) -> str:
+    if not _COMMIT.fullmatch(value):
+        raise ValueError("resolved_commit must be a 40-character lowercase Git commit")
+    return value
+
+
+def _sha256(value: str) -> str:
+    if not _SHA256.fullmatch(value):
+        raise ValueError("content_sha256 must be a 64-character lowercase SHA-256 digest")
+    return value
+
+
+def _relative_path(value: str, *, allow_empty: bool) -> str:
+    if value == "":
+        if allow_empty:
+            return value
+        raise ValueError("path cannot be empty")
+    path = PurePosixPath(value)
+    components = value.split("/")
+    if path.is_absolute() or any(component in {"", ".", ".."} for component in components):
+        raise ValueError("path must be relative and normalized")
+    return value
+
+
+class EnrollmentLock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = Field(default=1, alias="schema")
+    profile_id: str
+    source: str
+    requested_ref: str
+    resolved_commit: str
+    content_sha256: str
+    machine_id: str
+    subdirectory: str = ""
+    profile_file: str = "ai-dlc-profile.toml"
+
+    @property
+    def schema(self) -> Literal[1]:
+        return self.schema_version
+
+    @field_validator("profile_id", "machine_id")
+    @classmethod
+    def stable_ids(cls, value: str, info) -> str:
+        return _stable_id(value, info.field_name)
+
+    @field_validator("resolved_commit")
+    @classmethod
+    def commit(cls, value: str) -> str:
+        return _commit(value)
+
+    @field_validator("content_sha256")
+    @classmethod
+    def digest(cls, value: str) -> str:
+        return _sha256(value)
+
+    @field_validator("subdirectory")
+    @classmethod
+    def relative_subdirectory(cls, value: str) -> str:
+        return _relative_path(value, allow_empty=True)
+
+    @field_validator("profile_file")
+    @classmethod
+    def relative_profile_file(cls, value: str) -> str:
+        return _relative_path(value, allow_empty=False)
+
+
+@dataclass(frozen=True)
+class EnrollmentPaths:
+    config_root: Path
+    cache_root: Path
+    state_root: Path
+
+    @classmethod
+    def from_environment(
+        cls, home: Path | None = None, environ: Mapping[str, str] | None = None
+    ) -> "EnrollmentPaths":
+        environment = os.environ if environ is None else environ
+        user_home = Path.home() if home is None else Path(home)
+        config_home = Path(environment.get("XDG_CONFIG_HOME", user_home / ".config"))
+        cache_home = Path(environment.get("XDG_CACHE_HOME", user_home / ".cache"))
+        state_home = Path(environment.get("XDG_STATE_HOME", user_home / ".local/state"))
+        return cls(
+            config_root=config_home / "ai-dlc",
+            cache_root=cache_home / "ai-dlc",
+            state_root=state_home / "ai-dlc",
+        )
+
+    @property
+    def lock_file(self) -> Path:
+        return self.config_root / "enrollment.toml"
+
+    def machine_file(self, machine_id: str) -> Path:
+        return self.config_root / "machines" / f"{_stable_id(machine_id, 'machine_id')}.toml"
+
+    def profile_root(self, profile_id: str, resolved_commit: str) -> Path:
+        return (
+            self.cache_root
+            / "profiles"
+            / _stable_id(profile_id, "profile_id")
+            / _commit(resolved_commit)
+        )
+
+
+def read_lock(paths: EnrollmentPaths) -> EnrollmentLock | None:
+    if not paths.lock_file.exists():
+        return None
+    return EnrollmentLock.model_validate(tomllib.loads(paths.lock_file.read_text()))
+
+
+def write_lock(paths: EnrollmentPaths, lock: EnrollmentLock) -> Path:
+    atomic_write(paths.lock_file, tomli_w.dumps(lock.model_dump(by_alias=True)), mode=0o600)
+    return paths.lock_file
+
+
+def ensure_machine_file(paths: EnrollmentPaths, machine_id: str) -> Path:
+    path = paths.machine_file(machine_id)
+    atomic_create(path, tomli_w.dumps({"schema": 4}), mode=0o600)
+    return path
+
+
+def active_profile_file(paths: EnrollmentPaths, lock: EnrollmentLock) -> Path:
+    return (
+        paths.profile_root(lock.profile_id, lock.resolved_commit)
+        / lock.subdirectory
+        / lock.profile_file
+    )

--- a/src/ai_dlc/files.py
+++ b/src/ai_dlc/files.py
@@ -20,17 +20,39 @@ def inside(root: Path, relative: str) -> Path:
     return candidate
 
 
-def atomic_write(path: Path, data: str) -> None:
+def atomic_write(path: Path, data: str, mode: int | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    final_mode = (
+        mode if mode is not None else path.stat().st_mode & 0o777 if path.exists() else 0o644
+    )
     fd, name = tempfile.mkstemp(dir=path.parent, prefix=".ai-dlc-")
     try:
         with os.fdopen(fd, "w") as stream:
             stream.write(data)
             stream.flush()
             os.fsync(stream.fileno())
-        os.chmod(name, mode)
+        os.chmod(name, final_mode)
         os.replace(name, path)
+    finally:
+        if os.path.exists(name):
+            os.unlink(name)
+
+
+def atomic_create(path: Path, data: str, mode: int) -> bool:
+    """Create a file from a private staging file without replacing an existing path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(dir=path.parent, prefix=".ai-dlc-")
+    try:
+        with os.fdopen(descriptor, "w") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(name, mode)
+        try:
+            os.link(name, path)
+        except FileExistsError:
+            return False
+        return True
     finally:
         if os.path.exists(name):
             os.unlink(name)

--- a/src/ai_dlc/machine.py
+++ b/src/ai_dlc/machine.py
@@ -1,0 +1,533 @@
+"""Preview-first enrollment and offline status for portable machine profiles."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import tomllib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, NoReturn
+
+from ai_dlc.config import resolve_layers
+from ai_dlc.credentials import credential_status
+from ai_dlc.enrollment import (
+    EnrollmentLock,
+    EnrollmentPaths,
+    ensure_machine_file,
+    read_lock,
+    write_lock,
+)
+from ai_dlc.profile_source import (
+    ProfileCandidate,
+    redact_source,
+    resolve_profile_source,
+    source_lock_value,
+    source_portability,
+    verify_cached_profile,
+)
+from ai_dlc.user_agents import UserAgentOwnershipConflict, render_user_agents
+
+
+class MachineManager:
+    """Compose enrollment metadata with the existing profile and readiness services."""
+
+    def __init__(
+        self,
+        *,
+        home: Path | None = None,
+        environ: Mapping[str, str] | None = None,
+        paths: EnrollmentPaths | None = None,
+    ) -> None:
+        self.home = (Path.home() if home is None else Path(home)).resolve()
+        self.environ = os.environ if environ is None else environ
+        self.paths = paths or EnrollmentPaths.from_environment(home=self.home, environ=self.environ)
+
+    def enroll(
+        self,
+        source: str,
+        profile_id: str,
+        machine_id: str,
+        *,
+        requested_ref: str = "main",
+        subdirectory: str = "",
+        apply: bool = False,
+    ) -> dict[str, object]:
+        candidate = self._candidate(
+            source,
+            profile_id,
+            requested_ref,
+            subdirectory=subdirectory,
+        )
+        return self._enrollment_preview(candidate, machine_id, apply=apply)
+
+    def migrate(
+        self,
+        source: str,
+        profile_file: str,
+        profile_id: str,
+        machine_id: str,
+        *,
+        requested_ref: str = "main",
+        subdirectory: str = "",
+        apply: bool = False,
+    ) -> dict[str, object]:
+        candidate = self._candidate(
+            source,
+            profile_id,
+            requested_ref,
+            subdirectory=subdirectory,
+            profile_file=profile_file,
+            allow_legacy_identity=True,
+        )
+        return self._enrollment_preview(candidate, machine_id, apply=apply)
+
+    def status(self, root: Path | None = None) -> dict[str, object]:
+        """Report only local enrollment state; never contact the profile source."""
+        del root
+        lock = read_lock(self.paths)
+        if lock is None:
+            return {
+                "enrolled": False,
+                "ready": False,
+                "next": "Enroll a profile with ai-dlc machine enroll <source> --profile-id <id> --machine-id <id>.",
+            }
+
+        profile = self._profile_summary_from_lock(lock)
+        machine_file = self.paths.machine_file(lock.machine_id)
+        machine = {
+            "id": lock.machine_id,
+            "path": str(machine_file),
+            "exists": machine_file.is_file(),
+        }
+        drift: list[str] = []
+        if not machine["exists"]:
+            drift.append("machine binding is missing")
+
+        try:
+            profile_file = verify_cached_profile(lock, self.paths)
+        except RuntimeError:
+            drift.append("cache is corrupt")
+            return {
+                "enrolled": True,
+                "ready": False,
+                "profile": profile,
+                "cache": "corrupt",
+                "machine": machine,
+                "credentials": [],
+                "drift": drift,
+            }
+
+        try:
+            config = self._resolved_config(
+                profile_file, machine_file if machine["exists"] else None
+            )
+        except (OSError, tomllib.TOMLDecodeError, TypeError, ValueError):
+            drift.append("machine binding is invalid")
+            config = self._personal_config(profile_file)
+
+        credentials = credential_status(config, self.environ)
+        missing_credentials = (
+            [entry for entry in credentials if not entry["present"]]
+            if machine["exists"] and "machine binding is invalid" not in drift
+            else []
+        )
+        for entry in missing_credentials:
+            credential_id = entry["id"]
+            variable = entry.get("variable")
+            if isinstance(variable, str):
+                drift.append(f"credential {credential_id} is missing: {variable}")
+            else:
+                drift.append(f"credential {credential_id} is not bound")
+        return {
+            "enrolled": True,
+            "ready": not drift,
+            "profile": profile,
+            "cache": "healthy",
+            "machine": machine,
+            "credentials": credentials,
+            "drift": drift,
+        }
+
+    def plan(self, *, headless: bool = False, profile: Path | None = None) -> dict[str, object]:
+        """Preview reconciliation from the active machine and selected personal profile."""
+        from ai_dlc import provision
+
+        lock, profile_file, machine_file = self._active_files(profile=profile)
+        result = provision.machine_plan(
+            profile_file,
+            headless=headless,
+            home=self.home,
+            machine=machine_file,
+            environ=self.environ,
+        )
+        return self._with_lock(result, lock)
+
+    def apply(self, *, headless: bool = False, profile: Path | None = None) -> dict[str, object]:
+        """Reconcile the active machine and selected personal profile without mutation."""
+        from ai_dlc import provision
+
+        lock, profile_file, machine_file = self._active_files(profile=profile)
+        result = provision.machine_apply(
+            profile_file,
+            headless=headless,
+            home=self.home,
+            machine=machine_file,
+            environ=self.environ,
+        )
+        return self._with_lock(result, lock)
+
+    def sync(self, *, apply: bool = False, headless: bool = False) -> dict[str, object]:
+        """Resolve a candidate ref and activate it only after successful reconciliation."""
+        from ai_dlc import provision
+
+        lock = read_lock(self.paths)
+        if lock is None:
+            raise RuntimeError("machine is not enrolled")
+        prior_lock_bytes = self.paths.lock_file.read_bytes()
+        try:
+            active_profile = verify_cached_profile(lock, self.paths)
+            machine_file = self._active_machine_file(lock)
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure("active state validation", prior_lock_bytes, exc)
+
+        try:
+            candidate = self._candidate(
+                lock.source,
+                lock.profile_id,
+                lock.requested_ref,
+                subdirectory=lock.subdirectory,
+                profile_file=lock.profile_file,
+                allow_legacy_identity=(
+                    "profile_id" not in tomllib.loads(active_profile.read_text())
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure("candidate resolution", prior_lock_bytes, exc)
+
+        candidate_lock = self._lock_from_candidate(candidate, lock.machine_id)
+        candidate_profile = candidate.cache_root / candidate.subdirectory / candidate.profile_file
+        configuration_diff = "".join(
+            difflib.unified_diff(
+                active_profile.read_text().splitlines(True),
+                candidate_profile.read_text().splitlines(True),
+                fromfile=lock.resolved_commit,
+                tofile=candidate.resolved_commit,
+            )
+        )
+        changes = {
+            "resolved_commit": {
+                "from": lock.resolved_commit,
+                "to": candidate.resolved_commit,
+            },
+            "content_sha256": {
+                "from": lock.content_sha256,
+                "to": candidate.content_sha256,
+            },
+            "configuration": configuration_diff,
+        }
+        try:
+            config = self._resolved_config(candidate_profile, machine_file)
+            credentials = credential_status(config, self.environ)
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure("candidate readiness", prior_lock_bytes, exc)
+        idempotent = candidate_lock == lock
+        base_result: dict[str, object] = {
+            "applied": False,
+            "idempotent": idempotent,
+            "lock": candidate_lock.model_dump(by_alias=True),
+            "changes": changes,
+            "readiness": {
+                "ready": all(bool(entry["present"]) for entry in credentials),
+                "credentials": credentials,
+            },
+        }
+        if idempotent:
+            return base_result
+
+        try:
+            plan = provision.machine_plan(
+                candidate_profile,
+                headless=headless,
+                home=self.home,
+                machine=machine_file,
+                environ=self.environ,
+            )
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure("candidate planning", prior_lock_bytes, exc)
+        base_result["plan"] = plan
+        if not apply:
+            return base_result
+
+        try:
+            reconciliation = provision.machine_apply(
+                candidate_profile,
+                headless=headless,
+                home=self.home,
+                machine=machine_file,
+                environ=self.environ,
+            )
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure(
+                "reconciliation",
+                prior_lock_bytes,
+                exc,
+                package_side_effects=True,
+            )
+        try:
+            write_lock(self.paths, candidate_lock)
+        except Exception as exc:  # noqa: BLE001 -- every failure must preserve the lock
+            self._raise_sync_failure(
+                "lock activation",
+                prior_lock_bytes,
+                exc,
+                package_side_effects=True,
+            )
+        return {
+            **base_result,
+            "applied": True,
+            "reconciliation": reconciliation,
+        }
+
+    def doctor(
+        self, root: Path, *, target: str = "local", machine: Path | None = None
+    ) -> dict[str, object]:
+        """Combine enrollment state with shared project and provider diagnostics."""
+        from ai_dlc import provision
+
+        lock = read_lock(self.paths)
+        profile_file: Path | None = None
+        machine_file: Path | None = None
+        unavailable: list[str] = []
+        if machine is None:
+            machine_status = self.status(root)
+            if lock is None:
+                unavailable.extend(["verified profile cache", "machine binding"])
+            else:
+                try:
+                    profile_file = verify_cached_profile(lock, self.paths)
+                except RuntimeError:
+                    unavailable.append("verified profile cache")
+                selected_machine = self.paths.machine_file(lock.machine_id)
+                drift = machine_status.get("drift", [])
+                machine_invalid = isinstance(drift, list) and "machine binding is invalid" in drift
+                if selected_machine.is_file() and not machine_invalid:
+                    machine_file = selected_machine
+                else:
+                    unavailable.append("machine binding")
+        elif lock is not None:
+            try:
+                profile_file = verify_cached_profile(lock, self.paths)
+            except RuntimeError:
+                unavailable.append("verified profile cache")
+        if machine is not None:
+            machine_file = machine
+        needs_user_agent_readiness = (
+            machine is None and (profile_file is None or machine_file is None)
+        ) or (machine is not None and lock is not None and profile_file is None)
+        if needs_user_agent_readiness:
+            unavailable.append("complete user-agent readiness")
+        checks = provision.doctor(
+            root,
+            target=target,
+            personal=profile_file,
+            machine=machine_file,
+            home=self.home,
+            environ=self.environ,
+        )
+        if machine is not None:
+            effective_ready = (
+                bool(checks["ready"])
+                and machine.is_file()
+                and (lock is None or profile_file is not None)
+            )
+            machine_status = {
+                "enrolled": lock is not None,
+                "ready": effective_ready,
+                "machine": {
+                    "path": str(machine),
+                    "exists": machine.is_file(),
+                    "override": True,
+                },
+                "drift": unavailable,
+            }
+        else:
+            effective_ready = bool(machine_status["ready"]) and bool(checks["ready"])
+        return {
+            **checks,
+            "ready": effective_ready,
+            "machine_status": machine_status,
+            "machine_checks": {
+                "available": not unavailable,
+                "unavailable": unavailable,
+            },
+        }
+
+    def _candidate(
+        self,
+        source: str,
+        profile_id: str,
+        requested_ref: str,
+        *,
+        subdirectory: str,
+        profile_file: str = "ai-dlc-profile.toml",
+        allow_legacy_identity: bool = False,
+    ) -> ProfileCandidate:
+        return resolve_profile_source(
+            source,
+            profile_id,
+            requested_ref,
+            self.paths,
+            subdirectory=subdirectory,
+            profile_file=profile_file,
+            allow_legacy_identity=allow_legacy_identity,
+            environ=self.environ,
+        )
+
+    def _active_files(
+        self, *, profile: Path | None = None
+    ) -> tuple[EnrollmentLock | None, Path, Path | None]:
+        lock = read_lock(self.paths)
+        if lock is None:
+            if profile is None:
+                raise RuntimeError("machine is not enrolled")
+            return None, profile, None
+        return (
+            lock,
+            profile or verify_cached_profile(lock, self.paths),
+            self._active_machine_file(lock),
+        )
+
+    @staticmethod
+    def _with_lock(result: dict[str, object], lock: EnrollmentLock | None) -> dict[str, object]:
+        if lock is None:
+            return result
+        return {**result, "lock": lock.model_dump(by_alias=True)}
+
+    def _active_machine_file(self, lock: EnrollmentLock) -> Path:
+        machine_file = self.paths.machine_file(lock.machine_id)
+        if not machine_file.is_file():
+            raise RuntimeError("active machine binding is missing")
+        return machine_file
+
+    @staticmethod
+    def _lock_from_candidate(candidate: ProfileCandidate, machine_id: str) -> EnrollmentLock:
+        return EnrollmentLock(
+            profile_id=candidate.profile_id,
+            source=source_lock_value(candidate.source),
+            requested_ref=candidate.requested_ref,
+            resolved_commit=candidate.resolved_commit,
+            content_sha256=candidate.content_sha256,
+            machine_id=machine_id,
+            subdirectory=candidate.subdirectory,
+            profile_file=candidate.profile_file,
+        )
+
+    def _raise_sync_failure(
+        self,
+        step: str,
+        prior_lock_bytes: bytes,
+        error: Exception,
+        *,
+        package_side_effects: bool = False,
+    ) -> NoReturn:
+        try:
+            lock_unchanged = self.paths.lock_file.read_bytes() == prior_lock_bytes
+        except OSError:
+            lock_unchanged = False
+        if not lock_unchanged:
+            raise RuntimeError(
+                f"machine sync failed during {step}; active lock changed unexpectedly"
+            ) from error
+        partial = "; package-side effects may be partial" if package_side_effects else ""
+        raise RuntimeError(
+            f"machine sync failed during {step}; active lock preserved{partial}"
+        ) from error
+
+    def _enrollment_preview(
+        self, candidate: ProfileCandidate, machine_id: str, *, apply: bool
+    ) -> dict[str, object]:
+        lock = self._lock_from_candidate(candidate, machine_id)
+        current = read_lock(self.paths)
+        machine_file = self.paths.machine_file(machine_id)
+        config = self._resolved_config(
+            candidate.cache_root / candidate.subdirectory / candidate.profile_file,
+            machine_file if machine_file.is_file() else None,
+        )
+        agent_preview, conflicts = self._agent_preview(config)
+        profile_change = (
+            {"from": current.profile_id, "to": lock.profile_id}
+            if current is not None and current.profile_id != lock.profile_id
+            else None
+        )
+        idempotent = current == lock and machine_file.is_file()
+        result: dict[str, object] = {
+            "applied": apply,
+            "idempotent": idempotent,
+            "profile": {
+                "id": candidate.profile_id,
+                "source": candidate.source,
+                "requested_ref": candidate.requested_ref,
+                "resolved_commit": candidate.resolved_commit,
+                "content_sha256": candidate.content_sha256,
+                "portable": candidate.portable,
+                "profile_file": candidate.profile_file,
+            },
+            "lock": lock.model_dump(by_alias=True),
+            "machine": {
+                "id": machine_id,
+                "path": str(machine_file),
+                "exists": machine_file.is_file() or apply,
+            },
+            "modules": self._selected_modules(config),
+            "credentials": credential_status(config, self.environ),
+            "user_agents": agent_preview,
+            "ownership_conflicts": conflicts,
+            "profile_change": profile_change,
+        }
+        if apply:
+            ensure_machine_file(self.paths, machine_id)
+            # The cache, binding, and complete result are validated before active-state mutation.
+            write_lock(self.paths, lock)
+        return result
+
+    def _agent_preview(self, config: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+        try:
+            return render_user_agents(config, self.home, apply=False), []
+        except UserAgentOwnershipConflict as error:
+            return {"clean": False, "changed": [], "applied": False}, [str(error)]
+
+    @staticmethod
+    def _selected_modules(config: dict[str, Any]) -> list[str]:
+        modules = config.get("modules", {})
+        if not isinstance(modules, Mapping):
+            raise TypeError("modules must be a table")
+        selected = modules.get("include", ["core"])
+        if not isinstance(selected, list) or not all(
+            isinstance(module, str) for module in selected
+        ):
+            raise ValueError("modules.include must be a list of module IDs")
+        return selected
+
+    @staticmethod
+    def _personal_config(profile_file: Path) -> dict[str, Any]:
+        return tomllib.loads(profile_file.read_text())
+
+    def _resolved_config(self, profile_file: Path, machine_file: Path | None) -> dict[str, Any]:
+        layers: list[tuple[str, dict[str, Any]]] = [
+            ("personal", self._personal_config(profile_file))
+        ]
+        if machine_file is not None:
+            layers.append(("machine", tomllib.loads(machine_file.read_text())))
+        return resolve_layers(layers).values
+
+    @staticmethod
+    def _profile_summary_from_lock(lock: EnrollmentLock) -> dict[str, object]:
+        source = redact_source(lock.source)
+        return {
+            "id": lock.profile_id,
+            "source": source,
+            "requested_ref": lock.requested_ref,
+            "resolved_commit": lock.resolved_commit,
+            "portable": source_portability(lock.source),
+        }

--- a/src/ai_dlc/profile_source.py
+++ b/src/ai_dlc/profile_source.py
@@ -1,0 +1,511 @@
+"""Resolve one Git profile file into a pinned, digest-verified cache."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import os
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import tomllib
+import unicodedata
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from ai_dlc.config import resolve_layers
+from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths
+
+_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_SCHEME = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+_SCP_REMOTE = re.compile(
+    r"^(?:(?P<username>[A-Za-z0-9._~-]+)@)?"
+    r"(?P<host>\[[^\]]+\]|[^@:/\\]+):(?P<path>.+)$"
+)
+_GIT_TRANSPORT_HELPER = re.compile(r"^[^:/\\]+::")
+_PERCENT_ENCODED_BYTE = re.compile(r"%([0-9A-Fa-f]{2})")
+_SSH_USERNAME = re.compile(r"^[A-Za-z0-9._~-]+$")
+_DNS_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+_WINDOWS_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+_URL_SCHEMES = {"file", "https", "ssh"}
+_STRUCTURAL_DELIMITERS = frozenset(":/\\@?#%")
+_URI_ENCODED_DELIMITERS = frozenset(":/?#[]@!$&'()*+,;=%\\")
+_GIT_TIMEOUT_SECONDS = 30
+_REDACTED_SOURCE = "<redacted profile source>"
+_INVALID_SOURCE = "profile source is invalid"
+
+
+@dataclass(frozen=True)
+class ProfileCandidate:
+    profile_id: str
+    source: str
+    requested_ref: str
+    resolved_commit: str
+    content_sha256: str
+    subdirectory: str
+    profile_file: str
+    cache_root: Path
+    portable: bool
+
+
+def _relative_path(value: str, *, field: str, allow_empty: bool) -> PurePosixPath:
+    if not value:
+        if allow_empty:
+            return PurePosixPath()
+        raise ValueError(f"{field} must be a non-empty relative path")
+    if "\x00" in value:
+        raise ValueError(f"{field} must be a relative normalized path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in value.split("/")):
+        raise ValueError(f"{field} must be a relative normalized path")
+    return path
+
+
+def _selected_path(subdirectory: str, profile_file: str) -> PurePosixPath:
+    directory = _relative_path(subdirectory, field="subdirectory", allow_empty=True)
+    filename = _relative_path(profile_file, field="profile_file", allow_empty=False)
+    return directory / filename
+
+
+def _run_git(
+    repository: Path,
+    *arguments: str,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    if environ is None:
+        command = "git"
+    else:
+        command = shutil.which("git", path=environ.get("PATH", ""))
+        if command is None:
+            raise RuntimeError("Git is required to resolve a profile source")
+    try:
+        result = subprocess.run(
+            [command, "-C", str(repository), *arguments],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=environ,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError("Git is required to resolve a profile source") from error
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError("Git profile source operation timed out") from error
+    if result.returncode != 0:
+        raise RuntimeError("Git profile source operation failed")
+    return result.stdout.strip()
+
+
+def _resolve_commit(
+    repository: Path,
+    source: str,
+    requested_ref: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    _run_git(repository, "init", "--quiet", environ=environ)
+    if requested_ref.startswith("refs/"):
+        _run_git(repository, "check-ref-format", requested_ref, environ=environ)
+    else:
+        _run_git(repository, "check-ref-format", "--branch", requested_ref, environ=environ)
+    advertised = _run_git(
+        repository,
+        "ls-remote",
+        "--refs",
+        "--",
+        source,
+        requested_ref,
+        environ=environ,
+    )
+    matches = [line.split("\t", 1) for line in advertised.splitlines() if "\t" in line]
+    if len(matches) != 1:
+        raise RuntimeError("Git requested ref must identify exactly one advertised ref")
+    fetch_ref = matches[0][1]
+    _run_git(
+        repository,
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--",
+        source,
+        fetch_ref,
+        environ=environ,
+    )
+    commit = _run_git(
+        repository,
+        "rev-parse",
+        "--verify",
+        "FETCH_HEAD^{commit}",
+        environ=environ,
+    )
+    if not _COMMIT.fullmatch(commit):
+        raise RuntimeError("Git returned an invalid resolved commit")
+    _run_git(repository, "checkout", "--quiet", "--detach", commit, environ=environ)
+    return commit
+
+
+def _read_regular_file(root: Path, relative_path: PurePosixPath) -> bytes:
+    root = root.resolve(strict=True)
+    current = root
+    parts = relative_path.parts
+    for index, part in enumerate(parts):
+        current = current / part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError as error:
+            raise ValueError(f"profile file does not exist: {relative_path.as_posix()}") from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError(f"profile path cannot contain a symlink: {relative_path.as_posix()}")
+        if index < len(parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
+            raise ValueError(f"profile path is not a directory: {relative_path.as_posix()}")
+    if not stat.S_ISREG(current.lstat().st_mode):
+        raise ValueError(f"profile path must be a regular file: {relative_path.as_posix()}")
+    try:
+        current.resolve(strict=True).relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            f"profile path escapes the repository: {relative_path.as_posix()}"
+        ) from error
+    return current.read_bytes()
+
+
+def _validate_profile(content: bytes, profile_id: str, *, allow_legacy_identity: bool) -> None:
+    try:
+        document = tomllib.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ValueError("profile file must be valid UTF-8 TOML") from error
+    declared_identity = document.get("profile_id")
+    if declared_identity is None and not allow_legacy_identity:
+        raise ValueError("profile_id is required in a personal profile")
+    if declared_identity is not None and declared_identity != profile_id:
+        raise ValueError("profile_id does not match the requested profile")
+    resolve_layers([("personal", document)])
+
+
+def _content_digest(relative_path: PurePosixPath, content: bytes) -> str:
+    digest = hashlib.sha256()
+    digest.update(relative_path.as_posix().encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update(str(len(content)).encode("ascii"))
+    digest.update(b"\x00")
+    digest.update(content)
+    return digest.hexdigest()
+
+
+def _verify_cache_tree(
+    cache_root: Path, relative_path: PurePosixPath, expected_digest: str
+) -> Path:
+    try:
+        root_metadata = cache_root.lstat()
+    except FileNotFoundError as error:
+        raise RuntimeError("cached profile is missing") from error
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(root_metadata.st_mode):
+        raise RuntimeError("cached profile is corrupt")
+
+    expected_entries = {
+        PurePosixPath(*relative_path.parts[:index]) for index in range(1, len(relative_path.parts))
+    }
+    expected_entries.add(relative_path)
+    actual_entries: set[PurePosixPath] = set()
+    for directory, directory_names, filenames in os.walk(cache_root, followlinks=False):
+        parent = Path(directory)
+        for name in [*directory_names, *filenames]:
+            path = parent / name
+            relative = PurePosixPath(path.relative_to(cache_root).as_posix())
+            actual_entries.add(relative)
+            if path.is_symlink():
+                raise RuntimeError("cached profile is corrupt")
+    if actual_entries != expected_entries:
+        raise RuntimeError("cached profile is corrupt")
+
+    try:
+        content = _read_regular_file(cache_root, relative_path)
+    except ValueError as error:
+        raise RuntimeError("cached profile is corrupt") from error
+    if _content_digest(relative_path, content) != expected_digest:
+        raise RuntimeError("cached profile is corrupt")
+    return cache_root.joinpath(*relative_path.parts)
+
+
+def _materialize_cache(
+    destination: Path,
+    relative_path: PurePosixPath,
+    content: bytes,
+    expected_digest: str,
+) -> None:
+    if destination.exists() or destination.is_symlink():
+        _verify_cache_tree(destination, relative_path, expected_digest)
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staged = Path(tempfile.mkdtemp(prefix=".ai-dlc-profile-", dir=destination.parent))
+    try:
+        staged_file = staged.joinpath(*relative_path.parts)
+        staged_file.parent.mkdir(parents=True, exist_ok=True)
+        staged_file.write_bytes(content)
+        staged_file.chmod(0o600)
+        _verify_cache_tree(staged, relative_path, expected_digest)
+        try:
+            os.rename(staged, destination)
+        except OSError:
+            if not (destination.exists() or destination.is_symlink()):
+                raise
+            _verify_cache_tree(destination, relative_path, expected_digest)
+    finally:
+        if staged.exists() or staged.is_symlink():
+            shutil.rmtree(staged)
+
+
+def _git_source(source: str, kind: str) -> str:
+    """Normalize an existing local source without probing canonical URLs."""
+    if kind == "local":
+        source_path = Path(source)
+        if source_path.exists():
+            return str(source_path.resolve())
+    return source
+
+
+def source_portability(source: str) -> bool:
+    """Classify source portability from syntax alone, never filesystem state."""
+    return _source_kind(source) in {"https", "ssh", "scp"}
+
+
+def source_lock_value(source: str) -> str:
+    """Return the stable source representation stored in a new enrollment lock."""
+    kind = _source_kind(source)
+    if kind == "unsafe":
+        raise ValueError(_INVALID_SOURCE) from None
+    if kind in {"file", "https", "ssh", "scp"}:
+        return source
+    return _git_source(source, kind)
+
+
+def redact_source(source: str) -> str:
+    """Return a safe display value for a legacy source without ever raising."""
+    return _REDACTED_SOURCE if _source_kind(source) == "unsafe" else source
+
+
+def _source_kind(source: str) -> str:
+    """Classify the accepted source grammar without consulting the filesystem."""
+    if not _lexically_safe_source(source):
+        return "unsafe"
+    if _GIT_TRANSPORT_HELPER.match(source) is not None:
+        return "unsafe"
+    scheme_match = _SCHEME.match(source)
+    if scheme_match is not None:
+        scheme = scheme_match.group(1).lower()
+        suffix = source[scheme_match.end() :]
+        if scheme in _URL_SCHEMES:
+            return _canonical_url_kind(source, scheme, suffix)
+    if "://" in source:
+        return "unsafe"
+    if _WINDOWS_PATH.match(source):
+        return "local"
+    return _scp_or_local_kind(source)
+
+
+def _canonical_url_kind(source: str, scheme: str, suffix: str) -> str:
+    if not suffix.startswith("//"):
+        return "unsafe"
+    if "?" in suffix or "#" in suffix:
+        return "unsafe"
+    if "\\" in suffix or any(character.isspace() for character in source):
+        return "unsafe"
+    remainder = suffix[2:]
+    authority = remainder.split("/", 1)[0]
+    if not _valid_url_authority(authority, scheme):
+        return "unsafe"
+    return scheme
+
+
+def _lexically_safe_source(source: str) -> bool:
+    if not source or source != source.strip():
+        return False
+    if any(
+        chr(int(match.group(1), 16)) in _URI_ENCODED_DELIMITERS
+        for match in _PERCENT_ENCODED_BYTE.finditer(source)
+    ):
+        return False
+    for character in source:
+        codepoint = ord(character)
+        category = unicodedata.category(character)
+        if (
+            codepoint < 32
+            or codepoint == 127
+            or category[0] == "C"
+            or (character != " " and character.isspace())
+        ):
+            return False
+        normalized = unicodedata.normalize("NFKC", character)
+        if normalized != character and any(
+            normalized_character in _STRUCTURAL_DELIMITERS
+            or normalized_character.isspace()
+            or unicodedata.category(normalized_character)[0] == "C"
+            for normalized_character in normalized
+        ):
+            return False
+    return True
+
+
+def _valid_url_authority(authority: str, scheme: str) -> bool:
+    if not authority:
+        return scheme == "file"
+    if (
+        not authority.isascii()
+        or "%" in authority
+        or "\\" in authority
+        or any(character.isspace() for character in authority)
+    ):
+        return False
+
+    host_port = authority
+    if "@" in authority:
+        if scheme != "ssh" or authority.count("@") != 1:
+            return False
+        username, host_port = authority.split("@", 1)
+        if _SSH_USERNAME.fullmatch(username) is None:
+            return False
+
+    return _valid_host_port(host_port, allow_port=scheme != "file")
+
+
+def _valid_host_port(host_port: str, *, allow_port: bool) -> bool:
+    if host_port.startswith("["):
+        closing_bracket = host_port.find("]")
+        if closing_bracket < 0:
+            return False
+        host = host_port[1:closing_bracket]
+        remainder = host_port[closing_bracket + 1 :]
+        try:
+            ipaddress.IPv6Address(host)
+        except ValueError:
+            return False
+        if not remainder:
+            return True
+        return allow_port and remainder.startswith(":") and _valid_port(remainder[1:])
+
+    if host_port.count(":") > 1:
+        return False
+    if ":" in host_port:
+        if not allow_port:
+            return False
+        host, port = host_port.rsplit(":", 1)
+        if not _valid_port(port):
+            return False
+    else:
+        host = host_port
+    return _valid_host(host)
+
+
+def _valid_host(host: str) -> bool:
+    if not host or not host.isascii() or len(host) > 253:
+        return False
+    if all(character.isdigit() or character == "." for character in host) and "." in host:
+        try:
+            ipaddress.IPv4Address(host)
+        except ValueError:
+            return False
+        return True
+    normalized_host = host.removesuffix(".")
+    return bool(normalized_host) and all(
+        _DNS_LABEL.fullmatch(label) is not None for label in normalized_host.split(".")
+    )
+
+
+def _valid_port(port: str) -> bool:
+    return port.isascii() and port.isdigit() and 1 <= len(port) <= 5 and 1 <= int(port) <= 65535
+
+
+def _scp_or_local_kind(source: str) -> str:
+    match = _SCP_REMOTE.fullmatch(source)
+    if match is not None:
+        host = match.group("host")
+        path = match.group("path")
+        if (
+            _valid_scp_host(host)
+            and "@" not in path
+            and "\\" not in path
+            and not any(character.isspace() for character in path)
+        ):
+            return "scp"
+        return "unsafe"
+    colon = source.find(":")
+    first_separator = min(
+        (index for index in (source.find("/"), source.find("\\")) if index >= 0),
+        default=-1,
+    )
+    if colon >= 0 and (first_separator < 0 or colon < first_separator):
+        return "unsafe"
+    return "local"
+
+
+def _valid_scp_host(host: str) -> bool:
+    if host.startswith("[") and host.endswith("]"):
+        try:
+            ipaddress.IPv6Address(host[1:-1])
+        except ValueError:
+            return False
+        return True
+    return _valid_host(host)
+
+
+def resolve_profile_source(
+    source: str,
+    profile_id: str,
+    requested_ref: str,
+    paths: EnrollmentPaths,
+    *,
+    subdirectory: str = "",
+    profile_file: str = "ai-dlc-profile.toml",
+    allow_legacy_identity: bool = False,
+    environ: Mapping[str, str] | None = None,
+) -> ProfileCandidate:
+    """Resolve one requested Git ref and cache only its validated profile file."""
+    kind = _source_kind(source)
+    if kind == "unsafe":
+        raise ValueError(_INVALID_SOURCE) from None
+    relative_path = _selected_path(subdirectory, profile_file)
+    fetch_source = _git_source(source, kind)
+    portable = kind in {"https", "ssh", "scp"}
+    environment = None if environ is None else dict(environ)
+    paths.profile_root(profile_id, "0" * 40)
+    paths.cache_root.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix=".ai-dlc-profile-", dir=paths.cache_root.parent
+    ) as temporary_directory:
+        repository = Path(temporary_directory) / "repository"
+        repository.mkdir()
+        resolved_commit = _resolve_commit(
+            repository,
+            fetch_source,
+            requested_ref,
+            environ=environment,
+        )
+        content = _read_regular_file(repository, relative_path)
+        _validate_profile(content, profile_id, allow_legacy_identity=allow_legacy_identity)
+        content_sha256 = _content_digest(relative_path, content)
+
+    cache_root = paths.profile_root(profile_id, resolved_commit)
+    _materialize_cache(cache_root, relative_path, content, content_sha256)
+    return ProfileCandidate(
+        profile_id=profile_id,
+        source=source,
+        requested_ref=requested_ref,
+        resolved_commit=resolved_commit,
+        content_sha256=content_sha256,
+        subdirectory=subdirectory,
+        profile_file=profile_file,
+        cache_root=cache_root,
+        portable=portable,
+    )
+
+
+def verify_cached_profile(lock: EnrollmentLock, paths: EnrollmentPaths) -> Path:
+    """Verify and return an enrolled cached profile without contacting its source."""
+    relative_path = _selected_path(lock.subdirectory, lock.profile_file)
+    cache_root = paths.profile_root(lock.profile_id, lock.resolved_commit)
+    return _verify_cache_tree(cache_root, relative_path, lock.content_sha256)

--- a/src/ai_dlc/providers/__init__.py
+++ b/src/ai_dlc/providers/__init__.py
@@ -6,11 +6,13 @@ import importlib.metadata
 import importlib.util
 import json
 import math
+import os
 import queue
 import re
 import subprocess
 import sys
 import threading
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -46,9 +48,10 @@ def reject_unsafe_imports(files):
 
 
 class ExecutableProvider:
-    def __init__(self, config, *, bundled=False):
+    def __init__(self, config, *, bundled=False, environ: Mapping[str, str] | None = None):
         self.config = config
         self.bundled = bundled
+        self.environ = os.environ if environ is None else environ
         self.command = config["command"]
         if not bundled:
             verify_artifact(self.command, config.get("sha256"))
@@ -67,6 +70,7 @@ class ExecutableProvider:
             capture_output=True,
             timeout=self.config.get("timeout", 30),
             check=False,
+            env=self.environ,
         )
         if result.returncode:
             raise RuntimeError(f"Provider failed: {result.stderr.strip()}")
@@ -157,8 +161,9 @@ def module_manifest(distribution, files, hashes):
 
 
 class IsolatedPythonProvider(ExecutableProvider):
-    def __init__(self, config, modules, entry_point):
+    def __init__(self, config, modules, entry_point, *, environ=None):
         self.config, self.modules, self.entry_point = config, modules, entry_point
+        self.environ = os.environ if environ is None else environ
 
     def invoke(self, operation, payload):
         request = validate_request(operation, payload)
@@ -175,6 +180,7 @@ class IsolatedPythonProvider(ExecutableProvider):
             capture_output=True,
             timeout=self.config.get("timeout", 30),
             check=False,
+            env=self.environ,
         )
         if result.returncode:
             raise RuntimeError("Isolated Python provider failed: " + result.stderr.strip())
@@ -182,9 +188,10 @@ class IsolatedPythonProvider(ExecutableProvider):
 
 
 class Registry:
-    def __init__(self, config=None, *, root=None):
+    def __init__(self, config=None, *, root=None, environ: Mapping[str, str] | None = None):
         self.root = Path(root or Path.cwd())
         self.config = config or {}
+        self.environ = os.environ if environ is None else environ
         self.cache = {}
 
     def register(self, id, provider):
@@ -198,11 +205,11 @@ class Registry:
         if kind == "openspec":
             from .openspec import OpenSpecProvider
 
-            provider = OpenSpecProvider(self.root)
+            provider = OpenSpecProvider(self.root, environ=self.environ)
         elif kind in {"github", "github-scm", "github-deployment", "cloudflare"}:
             from .scm import GitHubSCM
 
-            provider = GitHubSCM(self.root, self.config)
+            provider = GitHubSCM(self.root, self.config, environ=self.environ)
         elif kind in {"obsidian", "knowledge"}:
             from ai_dlc.knowledge import Knowledge
 
@@ -213,7 +220,7 @@ class Registry:
         elif kind == "linear":
             from .linear import LinearProvider
 
-            provider = LinearProvider(cfg)
+            provider = LinearProvider(cfg, environ=self.environ)
         elif kind == "github-issues":
             provider = ExecutableProvider(
                 {
@@ -226,9 +233,10 @@ class Registry:
                     ],
                 },
                 bundled=True,
+                environ=self.environ,
             )
         elif kind == "executable":
-            provider = ExecutableProvider(cfg)
+            provider = ExecutableProvider(cfg, environ=self.environ)
         elif kind == "python":
             # A verified dependency lock plus the full installed distribution file set is mandatory.
             verify_artifact(cfg["dependency_lock"], cfg.get("dependency_lock_sha256"))
@@ -288,7 +296,7 @@ class Registry:
             entry_point = matches[0].value
             if entry_point.split(":", 1)[0] not in modules:
                 raise ValueError("Python provider import origin is outside verified distribution")
-            provider = IsolatedPythonProvider(cfg, modules, entry_point)
+            provider = IsolatedPythonProvider(cfg, modules, entry_point, environ=self.environ)
         else:
             raise ValueError(f"Unknown provider: {id}")
         self.cache[id] = provider

--- a/src/ai_dlc/providers/openspec.py
+++ b/src/ai_dlc/providers/openspec.py
@@ -1,11 +1,14 @@
+import os
 import re
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 
 class OpenSpecProvider:
-    def __init__(self, root):
+    def __init__(self, root, *, environ: Mapping[str, str] | None = None):
         self.root = Path(root).resolve()
+        self.environ = os.environ if environ is None else environ
 
     def current(self, work, revision=None):
         if revision is not None:
@@ -16,6 +19,7 @@ class OpenSpecProvider:
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=self.environ,
             )
             if not revision or head.returncode or head.stdout.strip() != revision:
                 raise ValueError("OpenSpec checkout revision must equal the merged revision")
@@ -26,6 +30,7 @@ class OpenSpecProvider:
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=self.environ,
             )
             if status.returncode or status.stdout.strip():
                 raise ValueError("OpenSpec files are dirty or untracked at the merged revision")
@@ -64,6 +69,7 @@ class OpenSpecProvider:
                 capture_output=True,
                 timeout=30,
                 check=False,
+                env=self.environ,
             )
             if tracked.returncode:
                 raise ValueError("OpenSpec archive must be tracked at the merged revision")
@@ -76,6 +82,7 @@ class OpenSpecProvider:
             capture_output=True,
             timeout=30,
             check=False,
+            env=self.environ,
         )
         if help_result.returncode:
             raise ValueError("Cannot discover installed OpenSpec capabilities")
@@ -90,6 +97,7 @@ class OpenSpecProvider:
                 capture_output=True,
                 timeout=60,
                 check=False,
+                env=self.environ,
             )
             if result.returncode:
                 raise ValueError("OpenSpec validation failed: " + result.stderr + result.stdout)

--- a/src/ai_dlc/providers/scm.py
+++ b/src/ai_dlc/providers/scm.py
@@ -4,10 +4,12 @@ import base64
 import hashlib
 import json
 import math
+import os
 import re
 import subprocess
 import tempfile
 import tomllib
+from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -77,9 +79,10 @@ def validate_receipt(receipt, sha, config, mise):
 
 
 class GitHubSCM:
-    def __init__(self, root, config):
+    def __init__(self, root, config, *, environ: Mapping[str, str] | None = None):
         self.root = Path(root)
         self.config = config
+        self.environ = os.environ if environ is None else environ
         self.scm = config.get("scm", {})
         self.repo = self.scm.get("repository", "")
         if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", self.repo):
@@ -88,7 +91,13 @@ class GitHubSCM:
 
     def run(self, *args):
         result = subprocess.run(
-            ["gh", *args], cwd=self.root, text=True, capture_output=True, timeout=60, check=False
+            ["gh", *args],
+            cwd=self.root,
+            text=True,
+            capture_output=True,
+            timeout=60,
+            check=False,
+            env=self.environ,
         )
         if result.returncode:
             raise RuntimeError(result.stderr.strip())

--- a/src/ai_dlc/provision.py
+++ b/src/ai_dlc/provision.py
@@ -8,12 +8,20 @@ import os
 import platform
 import shutil
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 import tomli_w
 
-from ai_dlc.config import SCHEMA, read_toml, resolve_files, resolve_layers
+from ai_dlc.config import SCHEMA, read_toml, resolve_files
+from ai_dlc.credentials import credential_status
 from ai_dlc.files import assets, atomic_write
+
+
+def _which(command: str, environ: Mapping[str, str] | None) -> str | None:
+    if environ is None:
+        return shutil.which(command)
+    return shutil.which(command, path=environ.get("PATH", ""))
 
 
 def machine_plan(
@@ -22,6 +30,8 @@ def machine_plan(
     system: str | None = None,
     architecture: str | None = None,
     home: Path | None = None,
+    machine: Path | None = None,
+    environ: Mapping[str, str] | None = None,
 ) -> dict:
     system = system or platform.system()
     architecture = architecture or platform.machine()
@@ -32,7 +42,7 @@ def machine_plan(
         "amd64",
     }:
         raise ValueError(f"unsupported machine: {system}/{architecture}")
-    config = resolve_layers([("personal", read_toml(profile))]).values
+    config = resolve_files(personal=profile, machine=machine).values
     catalog = read_toml(assets("modules") / "catalog.toml")
     chosen = config.get("modules", {}).get("include", ["core"])
     headless = headless or config.get("preferences", {}).get("headless", False)
@@ -78,35 +88,43 @@ def machine_plan(
         "guidance": guidance,
         "signins": signins,
         "headless": headless,
+        "credentials": credential_status(config, environ),
         "agent_configuration": agent_configuration,
     }
 
 
-def machine_apply(profile: Path, headless: bool = False, home: Path | None = None) -> dict:
-    plan = machine_plan(profile, headless, home=home)
+def machine_apply(
+    profile: Path,
+    headless: bool = False,
+    home: Path | None = None,
+    machine: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict:
+    plan = machine_plan(profile, headless, home=home, machine=machine, environ=environ)
     if plan["system"] == "Linux":
         release = platform.freedesktop_os_release()
         if release.get("ID") != "ubuntu" or release.get("VERSION_ID") not in {"24.04", "26.04"}:
             raise ValueError("supported Linux workstation releases are Ubuntu 24.04 and 26.04")
     home = (home or Path.home()).resolve()
-    root = Path(os.environ.get("XDG_DATA_HOME", str(home / ".local/share"))) / "ai-dlc/workstation"
+    environment = os.environ if environ is None else environ
+    root = Path(environment.get("XDG_DATA_HOME", str(home / ".local/share"))) / "ai-dlc/workstation"
     root.mkdir(parents=True, exist_ok=True)
-    config = resolve_layers([("personal", read_toml(profile))]).values
+    config = resolve_files(personal=profile, machine=machine).values
     from ai_dlc.user_agents import render_user_agents
 
     # Detect user-authored configuration conflicts before invoking package managers.
     render_user_agents(config, home)
     bootstrap_home = Path(
-        os.environ.get(
+        environment.get(
             "AI_DLC_BOOTSTRAP_HOME",
             str(
-                Path(os.environ.get("XDG_DATA_HOME", str(home / ".local/share")))
+                Path(environment.get("XDG_DATA_HOME", str(home / ".local/share")))
                 / "ai-dlc/bootstrap"
             ),
         )
     )
     bootstrap_bin = bootstrap_home / "bin"
-    mise = shutil.which("mise")
+    mise = _which("mise", environ)
     if not mise and (bootstrap_bin / "mise").is_file():
         mise = str(bootstrap_bin / "mise")
     if not mise:
@@ -115,7 +133,7 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
     if any(step["argv"][0] == "brew" for step in plan["commands"]):
         from ai_dlc.workstation import ensure_brew
 
-        brew = ensure_brew(root, plan["architecture"])
+        brew = ensure_brew(root, plan["architecture"], environ=environ)
     results = []
     runtimes = {}
     for step in plan["commands"]:
@@ -124,7 +142,7 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
             argv[0] = brew
         elif argv[0] == "mise":
             argv[0] = mise
-        elif not shutil.which(argv[0]):
+        elif not _which(argv[0], environ):
             raise RuntimeError(
                 f"{argv[0]} is required; install the native package manager before applying this module"
             )
@@ -135,8 +153,13 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
         if "mise" in step:
             runtimes.update(step["mise"])
             atomic_write(root / ".mise.toml", tomli_w.dumps({"tools": step["mise"]}))
-            subprocess.run([mise, "trust", str(root / ".mise.toml")], cwd=root, check=True)
-        subprocess.run(argv, cwd=root, check=True)
+            subprocess.run(
+                [mise, "trust", str(root / ".mise.toml")],
+                cwd=root,
+                check=True,
+                env=environment,
+            )
+        subprocess.run(argv, cwd=root, check=True, env=environment)
         results.append(argv)
     source = config.get("preferences", {}).get("dotfiles_source")
     if source:
@@ -144,6 +167,7 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
         subprocess.run(
             ["chezmoi", "--source", str(Path(source).expanduser()), "apply", "--interactive"],
             check=True,
+            env=environment,
         )
     from ai_dlc.workstation import activate_workstation
 
@@ -153,7 +177,7 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
         mise,
         bootstrap_bin,
         brew=brew,
-        shell=Path(os.environ.get("SHELL", "/bin/zsh")).name,
+        shell=Path(environment.get("SHELL", "/bin/zsh")).name,
     )
     agent_configuration = render_user_agents(config, home, apply=True)
     return {
@@ -166,12 +190,22 @@ def machine_apply(profile: Path, headless: bool = False, home: Path | None = Non
     }
 
 
-def doctor(root: Path, target: str = "local", machine: Path | None = None) -> dict:
+def doctor(
+    root: Path,
+    target: str = "local",
+    machine: Path | None = None,
+    *,
+    personal: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict:
     capabilities = read_toml(assets("targets") / "capabilities.toml")
     if target not in capabilities:
         raise ValueError(f"unsupported execution target: {target}")
-    config = resolve_files(project=root / "ai-dlc.toml", machine=machine).values
-    missing = [tool for tool in ["git", "mise"] if not shutil.which(tool)]
+    environment = os.environ if environ is None else environ
+    config = resolve_files(personal=personal, project=root / "ai-dlc.toml", machine=machine).values
+    credentials = credential_status(config, environment)
+    missing = [tool for tool in ["git", "mise"] if not _which(tool, environ)]
     runtime_drift = []
     if "mise" not in missing:
         result = subprocess.run(
@@ -181,6 +215,7 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
             text=True,
             timeout=30,
             check=False,
+            env=environment,
         )
         if result.returncode:
             runtime_drift.append("mise could not resolve this project; run project setup")
@@ -201,9 +236,13 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
         return settings.get("kind", settings.get("type", name))
 
     if kind("scm") in {"github", "github-scm"} or kind("tracker") == "github-issues":
-        if shutil.which("gh"):
+        if _which("gh", environ):
             status = subprocess.run(
-                ["gh", "auth", "status"], capture_output=True, timeout=30, check=False
+                ["gh", "auth", "status"],
+                capture_output=True,
+                timeout=30,
+                check=False,
+                env=environment,
             )
             if status.returncode:
                 signins.append("gh auth login")
@@ -218,9 +257,6 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
         configuration.append("tracker repository is required")
     if kind("tracker") == "linear":
         settings = providers.get(roles["tracker"], {})
-        token_env = settings.get("token_env", "LINEAR_API_KEY")
-        if not os.environ.get(token_env):
-            signins.append(f"Set {token_env} using your credential store")
         if not settings.get("team_id"):
             configuration.append("tracker team_id is required for creation")
         for state in ["in_progress", "closed"]:
@@ -228,14 +264,20 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
                 configuration.append("tracker statuses." + state + " is required")
     from ai_dlc.providers import Registry
 
-    registry = Registry(config, root=root)
+    registry = Registry(config, root=root, environ=environment)
     for name, settings in providers.items():
         if settings.get("health_reference"):
             try:
                 registry.invoke(name, "read", {"reference": settings["health_reference"]})
                 health.append({"provider": name, "ready": True})
-            except Exception as exc:  # noqa: BLE001 -- doctor must report provider failures
-                health.append({"provider": name, "ready": False, "reason": str(exc)})
+            except Exception:  # noqa: BLE001 -- doctor must report provider failures
+                health.append(
+                    {
+                        "provider": name,
+                        "ready": False,
+                        "reason": "provider health check failed",
+                    }
+                )
     from ai_dlc.agents import render_agents, target_hooks
 
     hooks = target_hooks(config, target)
@@ -247,10 +289,37 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
         conflicts = [str(exc)]
     vault = config.get("paths", {}).get("vault")
     knowledge = "available" if vault and Path(vault).expanduser().is_dir() else "unavailable"
+    if personal is None:
+        user_agents: dict[str, object] = {"clean": True, "changed": [], "applied": False}
+    else:
+        from ai_dlc.user_agents import UserAgentOwnershipConflict, render_user_agents
+
+        try:
+            user_agents = render_user_agents(
+                config,
+                (Path.home() if home is None else Path(home)).resolve(),
+                apply=False,
+            )
+        except UserAgentOwnershipConflict as exc:
+            user_agents = {
+                "clean": False,
+                "changed": [],
+                "applied": False,
+                "conflicts": [str(exc)],
+            }
+    for credential in credentials:
+        if credential["present"]:
+            continue
+        variable = credential.get("variable")
+        if isinstance(variable, str):
+            signins.append(f"Set {variable} using your credential store")
+        else:
+            signins.append(f"Bind credential {credential['id']} in machine configuration")
     return {
         "ready": not (missing or runtime_drift or signins or conflicts or configuration)
         and hooks["ready"]
-        and all(item["ready"] for item in health),
+        and all(item["ready"] for item in health)
+        and bool(user_agents["clean"]),
         "target": target,
         "capabilities": capabilities[target],
         "missing": missing,
@@ -261,6 +330,8 @@ def doctor(root: Path, target: str = "local", machine: Path | None = None) -> di
         "managed_conflicts": conflicts,
         "knowledge": knowledge,
         "hooks": hooks,
+        "credentials": credentials,
+        "user_agents": user_agents,
     }
 
 

--- a/src/ai_dlc/user_agents.py
+++ b/src/ai_dlc/user_agents.py
@@ -24,6 +24,10 @@ _CODEX_SECTION = re.compile(
 )
 
 
+class UserAgentOwnershipConflict(ValueError):
+    """A persisted client configuration prevents AI-DLC from safely changing it."""
+
+
 def render_user_agents(
     config: dict[str, Any],
     home: Path,
@@ -187,14 +191,16 @@ def _plan_claude(
     try:
         document = json.loads(path.read_text()) if existed else {}
     except (json.JSONDecodeError, OSError) as exc:
-        raise ValueError("Claude user configuration conflict: invalid JSON") from exc
+        raise UserAgentOwnershipConflict(
+            "Claude user configuration conflict: invalid JSON"
+        ) from exc
     if not isinstance(document, dict):
-        raise ValueError(  # noqa: TRY004 -- persisted configuration is semantically invalid
+        raise UserAgentOwnershipConflict(
             "Claude user configuration conflict: root must be an object"
         )
     current = document.get("mcpServers", {})
     if not isinstance(current, dict):
-        raise ValueError(  # noqa: TRY004 -- persisted configuration is semantically invalid
+        raise UserAgentOwnershipConflict(
             "Claude user configuration conflict: mcpServers must be an object"
         )
     _check_owned(current, old, "Claude")
@@ -232,20 +238,24 @@ def _plan_codex(
     section = _existing_codex_section(current_text)
     old = prior.get("servers", {})
     if section is not None and not old:
-        raise ValueError("Codex user configuration conflict: orphaned managed section")
+        raise UserAgentOwnershipConflict(
+            "Codex user configuration conflict: orphaned managed section"
+        )
     if not desired and not old:
         return
     try:
         document = tomllib.loads(current_text) if current_text else {}
     except tomllib.TOMLDecodeError as exc:
-        raise ValueError("Codex user configuration conflict: invalid TOML") from exc
+        raise UserAgentOwnershipConflict("Codex user configuration conflict: invalid TOML") from exc
     current = document.get("mcp_servers", {})
     if not isinstance(current, dict):
-        raise ValueError(  # noqa: TRY004 -- persisted configuration is semantically invalid
+        raise UserAgentOwnershipConflict(
             "Codex user configuration conflict: mcp_servers must be a table"
         )
     if old and section is None:
-        raise ValueError("Codex user configuration conflict: managed section is missing")
+        raise UserAgentOwnershipConflict(
+            "Codex user configuration conflict: managed section is missing"
+        )
     _check_owned(current, old, "Codex")
     unmanaged = {name: value for name, value in current.items() if name not in old}
     _check_unowned(unmanaged, desired, "Codex")
@@ -257,7 +267,9 @@ def _plan_codex(
         try:
             tomllib.loads(rendered)
         except tomllib.TOMLDecodeError as exc:
-            raise ValueError("Codex user configuration conflict: duplicate MCP tables") from exc
+            raise UserAgentOwnershipConflict(
+                "Codex user configuration conflict: duplicate MCP tables"
+            ) from exc
     clients["codex"] = {
         "created": prior.get("created", not existed),
         "separator_added": (
@@ -276,24 +288,32 @@ def _plan_codex(
 def _check_owned(current: dict, old: dict, label: str) -> None:
     for server_id, definition in old.items():
         if current.get(server_id) != definition:
-            raise ValueError(f"{label} user configuration conflict: managed server {server_id}")
+            raise UserAgentOwnershipConflict(
+                f"{label} user configuration conflict: managed server {server_id}"
+            )
 
 
 def _check_unowned(current: dict, desired: dict, label: str) -> None:
     collision = sorted(set(current) & set(desired))
     if collision:
-        raise ValueError(f"{label} user configuration conflict: unowned server {collision[0]}")
+        raise UserAgentOwnershipConflict(
+            f"{label} user configuration conflict: unowned server {collision[0]}"
+        )
 
 
 def _existing_codex_section(text: str) -> re.Match[str] | None:
     matches = list(_CODEX_SECTION.finditer(text))
     if len(matches) > 1 or (_CODEX_START in text and not matches):
-        raise ValueError("Codex user configuration conflict: malformed managed section")
+        raise UserAgentOwnershipConflict(
+            "Codex user configuration conflict: malformed managed section"
+        )
     if not matches:
         return None
     match = matches[0]
     if hashlib.sha256(match.group(2).encode()).hexdigest() != match.group(1):
-        raise ValueError("Codex user configuration conflict: managed section was edited")
+        raise UserAgentOwnershipConflict(
+            "Codex user configuration conflict: managed section was edited"
+        )
     return match
 
 
@@ -330,9 +350,9 @@ def _read_state(path: Path) -> dict[str, Any]:
     try:
         state = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError) as exc:
-        raise ValueError("user agent ownership conflict: invalid state") from exc
+        raise UserAgentOwnershipConflict("user agent ownership conflict: invalid state") from exc
     if state.get("schema") != 1 or not isinstance(state.get("clients"), dict):
-        raise ValueError("user agent ownership conflict: unsupported state")
+        raise UserAgentOwnershipConflict("user agent ownership conflict: unsupported state")
     return state
 
 

--- a/src/ai_dlc/workstation.py
+++ b/src/ai_dlc/workstation.py
@@ -2,9 +2,11 @@
 
 import hashlib
 import json
+import os
 import shlex
 import shutil
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 import httpx
@@ -15,8 +17,13 @@ from ai_dlc.config import read_toml
 from ai_dlc.files import assets, atomic_write
 
 
-def ensure_brew(root: Path, architecture: str) -> str:
-    existing = shutil.which("brew")
+def ensure_brew(root: Path, architecture: str, *, environ: Mapping[str, str] | None = None) -> str:
+    environment = os.environ if environ is None else environ
+    existing = (
+        shutil.which("brew")
+        if environ is None
+        else shutil.which("brew", path=environ.get("PATH", ""))
+    )
     if existing:
         return existing
     prefix = Path("/opt/homebrew" if architecture in {"arm64", "aarch64"} else "/usr/local")
@@ -30,7 +37,7 @@ def ensure_brew(root: Path, architecture: str) -> str:
         installer = root / "homebrew-install.sh"
         atomic_write(installer, response.text)
         # The native installer owns administrator access and interactive confirmation.
-        subprocess.run(["/bin/bash", str(installer)], check=True)
+        subprocess.run(["/bin/bash", str(installer)], check=True, env=environment)
     if not binary.is_file():
         raise RuntimeError("Homebrew installation incomplete; retry after native setup")
     return str(binary)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,99 @@
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+
+@dataclass(frozen=True)
+class LocalGitProfile:
+    repository: Path
+    source: str
+    profile_file: str
+    commit: str
+    environment: dict[str, str]
+
+    def advance(self, manifest: str, *, message: str = "advance profile") -> str:
+        path = self.repository / self.profile_file
+        path.write_text(manifest)
+        _git(self.repository, self.environment, "add", "--", self.profile_file)
+        _git(self.repository, self.environment, "commit", "-m", message)
+        return _git(self.repository, self.environment, "rev-parse", "HEAD")
+
+
+def _git(repository: Path, environment: dict[str, str], *arguments: str) -> str:
+    git = shutil.which("git", path=environment["PATH"])
+    assert git is not None
+    result = subprocess.run(
+        [git, "-C", str(repository), *arguments],
+        capture_output=True,
+        check=True,
+        env=environment,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def local_git_profile(tmp_path: Path) -> Callable[..., LocalGitProfile]:
+    """Create isolated local Git profile sources with explicit paths and commits."""
+    counter = 0
+
+    def create(manifest: str, *, profile_file: str = "ai-dlc-profile.toml") -> LocalGitProfile:
+        nonlocal counter
+        counter += 1
+        root = tmp_path / f"local-git-profile-{counter}"
+        repository = root / "repository"
+        git_home = root / "git-home"
+        git_config = root / "gitconfig"
+        repository.mkdir(parents=True)
+        git_home.mkdir()
+        real_git = shutil.which("git")
+        assert real_git is not None
+        environment = {
+            "PATH": str(Path(real_git).parent),
+            "HOME": str(git_home),
+            "XDG_CONFIG_HOME": str(root / "xdg-config"),
+            "XDG_CACHE_HOME": str(root / "xdg-cache"),
+            "XDG_STATE_HOME": str(root / "xdg-state"),
+            "GIT_CONFIG_GLOBAL": str(git_config),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": "/usr/bin/false",
+            "SSH_ASKPASS": "/usr/bin/false",
+            "LC_ALL": "C",
+        }
+        _git(repository, environment, "init", "-b", "main")
+        _git(repository, environment, "config", "user.name", "AI-DLC Test")
+        _git(repository, environment, "config", "user.email", "ai-dlc@example.test")
+        source = f"ssh://git@example.test/portable-profile-{counter}.git"
+        _git(
+            repository,
+            environment,
+            "config",
+            "--global",
+            f"url.{repository.as_uri()}.insteadOf",
+            source,
+        )
+        path = repository / profile_file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(manifest)
+        _git(repository, environment, "add", "--", profile_file)
+        _git(repository, environment, "commit", "-m", "add profile")
+        return LocalGitProfile(
+            repository=repository,
+            source=source,
+            profile_file=profile_file,
+            commit=_git(repository, environment, "rev-parse", "HEAD"),
+            environment=environment,
+        )
+
+    return create

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,45 @@
+import hashlib
+import json
+from pathlib import Path
+
 from typer.testing import CliRunner
+
+
+def _write_cli_enrollment(tmp_path: Path) -> dict[str, str]:
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, write_lock
+
+    environment = {
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        "XDG_CACHE_HOME": str(tmp_path / "cache"),
+        "XDG_STATE_HOME": str(tmp_path / "state"),
+    }
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "unused-home", environ=environment)
+    content = (
+        b'schema = 4\nprofile_id = "personal-profile"\n[roles]\nknowledge = "enrolled-personal"\n'
+    )
+    profile_file = "ai-dlc-profile.toml"
+    resolved_commit = "a" * 40
+    content_sha256 = hashlib.sha256(
+        profile_file.encode() + b"\0" + str(len(content)).encode() + b"\0" + content
+    ).hexdigest()
+    cached_profile = paths.profile_root("personal-profile", resolved_commit) / profile_file
+    cached_profile.parent.mkdir(parents=True)
+    cached_profile.write_bytes(content)
+    machine = paths.machine_file("workstation-01")
+    machine.parent.mkdir(parents=True)
+    machine.write_text('schema = 4\n[paths]\nworkspace = "/enrolled-machine"\n')
+    write_lock(
+        paths,
+        EnrollmentLock(
+            profile_id="personal-profile",
+            source="https://example.test/profiles.git",
+            requested_ref="main",
+            resolved_commit=resolved_commit,
+            content_sha256=content_sha256,
+            machine_id="workstation-01",
+        ),
+    )
+    return environment
 
 
 def test_command_help_exposes_public_groups():
@@ -6,8 +47,144 @@ def test_command_help_exposes_public_groups():
 
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
-    for name in ["project", "work", "setup", "profile", "knowledge", "mcp", "scaffold"]:
+    for name in [
+        "project",
+        "work",
+        "setup",
+        "profile",
+        "machine",
+        "knowledge",
+        "mcp",
+        "scaffold",
+    ]:
         assert name in result.stdout
+
+
+def test_machine_help_exposes_the_lifecycle_commands():
+    """Would fail if an enrolled-machine lifecycle route disappeared from the public CLI."""
+    from ai_dlc.cli import app
+
+    result = CliRunner().invoke(app, ["machine", "--help"])
+
+    assert result.exit_code == 0, result.output
+    for name in ["enroll", "migrate", "plan", "apply", "sync", "status", "doctor"]:
+        assert name in result.stdout
+
+
+def test_machine_commands_forward_their_documented_defaults(monkeypatch):
+    """Would fail if a lifecycle route changed its manager call or preview default."""
+    from ai_dlc import cli
+
+    calls = []
+
+    class Manager:
+        def enroll(self, source, profile_id, machine_id, **kwargs):
+            calls.append(("enroll", source, profile_id, machine_id, kwargs))
+            return {"route": "enroll"}
+
+        def migrate(self, source, profile_file, profile_id, machine_id, **kwargs):
+            calls.append(("migrate", source, profile_file, profile_id, machine_id, kwargs))
+            return {"route": "migrate"}
+
+        def plan(self, **kwargs):
+            calls.append(("plan", kwargs))
+            return {"route": "plan"}
+
+        def apply(self, **kwargs):
+            calls.append(("apply", kwargs))
+            return {"route": "apply"}
+
+        def sync(self, **kwargs):
+            calls.append(("sync", kwargs))
+            return {"route": "sync"}
+
+        def status(self):
+            calls.append(("status",))
+            return {"route": "status", "ready": True}
+
+        def doctor(self, root, *, target="local"):
+            calls.append(("doctor", root, target))
+            return {"route": "doctor", "ready": True}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager, raising=False)
+    runner = CliRunner()
+    invocations = [
+        [
+            "machine",
+            "enroll",
+            "/tmp/profile-repo",
+            "--profile-id",
+            "test-development",
+            "--machine-id",
+            "test-mac",
+        ],
+        [
+            "machine",
+            "enroll",
+            "/tmp/profile-repo",
+            "--profile-id",
+            "test-development",
+            "--machine-id",
+            "test-mac",
+            "--ref",
+            "stable",
+            "--subdirectory",
+            "config",
+            "--apply",
+        ],
+        [
+            "machine",
+            "migrate",
+            "/tmp/profile-repo",
+            "--profile-file",
+            "profiles/sean.toml",
+            "--profile-id",
+            "sean-development",
+            "--machine-id",
+            "personal-macbook",
+        ],
+        ["machine", "plan"],
+        ["machine", "apply"],
+        ["machine", "sync"],
+        ["machine", "sync", "--apply"],
+        ["machine", "status"],
+        ["machine", "doctor", "--root", "/tmp/project"],
+    ]
+
+    for invocation in invocations:
+        result = runner.invoke(cli.app, invocation)
+        assert result.exit_code == 0, result.output
+
+    assert calls == [
+        (
+            "enroll",
+            "/tmp/profile-repo",
+            "test-development",
+            "test-mac",
+            {"requested_ref": "main", "subdirectory": "", "apply": False},
+        ),
+        (
+            "enroll",
+            "/tmp/profile-repo",
+            "test-development",
+            "test-mac",
+            {"requested_ref": "stable", "subdirectory": "config", "apply": True},
+        ),
+        (
+            "migrate",
+            "/tmp/profile-repo",
+            "profiles/sean.toml",
+            "sean-development",
+            "personal-macbook",
+            {"requested_ref": "main", "subdirectory": "", "apply": False},
+        ),
+        ("plan", {"headless": False}),
+        ("apply", {"headless": False}),
+        ("sync", {"apply": False, "headless": False}),
+        ("sync", {"apply": True, "headless": False}),
+        ("status",),
+        ("doctor", Path("/tmp/project"), "local"),
+    ]
 
 
 def test_scaffold_matches_legacy_assets_and_preserves_conflicts(tmp_path, monkeypatch):
@@ -76,14 +253,255 @@ def test_setup_commands_accept_documented_profile_option(tmp_path, monkeypatch):
     monkeypatch.setattr(
         ai_dlc.provision,
         "machine_plan",
-        lambda profile, headless=False, home=None: {"profile": str(profile)},
+        lambda profile, headless=False, home=None, **kwargs: {"profile": str(profile)},
     )
     monkeypatch.setattr(
         ai_dlc.provision,
         "machine_apply",
-        lambda profile, headless=False, home=None: {"profile": str(profile)},
+        lambda profile, headless=False, home=None, **kwargs: {"profile": str(profile)},
     )
     runner = CliRunner()
     for action in ["plan", "apply"]:
         result = runner.invoke(app, ["setup", action, "--profile", str(profile)])
         assert result.exit_code == 0, result.output
+
+
+def test_setup_commands_without_a_profile_use_the_enrolled_manager(monkeypatch):
+    """Would fail if no-profile setup bypassed the active enrolled profile."""
+    from ai_dlc import cli
+
+    calls = []
+
+    class Manager:
+        def __init__(self, *, home=None):
+            self.home = home
+
+        def plan(self, *, headless=False, profile=None):
+            calls.append(("plan", self.home, headless, profile))
+            return {"route": "enrolled-plan", "home": str(self.home)}
+
+        def apply(self, *, headless=False, profile=None):
+            calls.append(("apply", self.home, headless, profile))
+            return {"route": "enrolled-apply", "home": str(self.home)}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager)
+    runner = CliRunner()
+
+    home = Path("/tmp/sandbox-home")
+    for action in ["plan", "apply"]:
+        result = runner.invoke(cli.app, ["setup", action, "--home", str(home)])
+        assert result.exit_code == 0, result.output
+        assert str(home) in result.stdout
+
+    assert calls == [("plan", home, False, None), ("apply", home, False, None)]
+
+
+def test_setup_profile_replacement_and_home_delegate_to_the_manager(monkeypatch, tmp_path):
+    """Would fail if setup bypassed the manager and lost the opposite enrolled scope."""
+    from ai_dlc import cli
+
+    profile = tmp_path / "replacement.toml"
+    home = tmp_path / "sandbox-home"
+    calls = []
+
+    class Manager:
+        def __init__(self, *, home=None):
+            self.home = home
+
+        def plan(self, *, headless=False, profile=None):
+            calls.append(("plan", self.home, headless, profile))
+            return {"home": str(self.home), "profile": str(profile)}
+
+        def apply(self, *, headless=False, profile=None):
+            calls.append(("apply", self.home, headless, profile))
+            return {"home": str(self.home), "profile": str(profile)}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager)
+    runner = CliRunner()
+
+    for action in ["plan", "apply"]:
+        result = runner.invoke(
+            cli.app, ["setup", action, "--profile", str(profile), "--home", str(home)]
+        )
+        assert result.exit_code == 0, result.output
+        assert str(home) in result.stdout
+        assert str(profile) in result.stdout
+
+    assert calls == [("plan", home, False, profile), ("apply", home, False, profile)]
+
+
+def test_profile_show_without_paths_uses_enrolled_runtime_resolution(monkeypatch):
+    """Would fail if profile show skipped verified enrollment layers by default."""
+    from ai_dlc import cli
+
+    calls = []
+
+    class Resolved:
+        def __init__(self):
+            self.values = {"profile_id": "enrolled"}
+            self.sources = {"profile_id": "personal"}
+
+    def runtime(root=None, *, base=None, personal=None, project=None, machine=None):
+        calls.append((root, base, personal, project, machine))
+        return Resolved()
+
+    monkeypatch.setattr(cli, "resolve_runtime", runtime, raising=False)
+
+    result = CliRunner().invoke(cli.app, ["profile", "show"])
+
+    assert result.exit_code == 0, result.output
+    assert '"profile_id": "enrolled"' in result.stdout
+    assert calls == [(None, None, None, None, None)]
+
+
+def test_profile_show_explicit_personal_keeps_enrolled_machine_and_composes_project(tmp_path):
+    from ai_dlc.cli import app
+
+    environment = _write_cli_enrollment(tmp_path)
+    personal = tmp_path / "personal.toml"
+    personal.write_text('schema = 4\n[roles]\nknowledge = "explicit-personal"\n')
+    project = tmp_path / "project.toml"
+    project.write_text('schema = 4\n[roles]\ntracker = "explicit-project"\n')
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "profile",
+            "show",
+            "--personal",
+            str(personal),
+            "--project",
+            str(project),
+        ],
+        env=environment,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["values"]["roles"]["knowledge"] == "explicit-personal"
+    assert payload["values"]["roles"]["tracker"] == "explicit-project"
+    assert payload["values"]["paths"]["workspace"] == "/enrolled-machine"
+    assert payload["sources"]["roles.knowledge"] == "personal"
+    assert payload["sources"]["roles.tracker"] == "project"
+    assert payload["sources"]["paths.workspace"] == "machine"
+
+
+def test_profile_show_explicit_machine_keeps_enrolled_personal_and_composes_project(tmp_path):
+    from ai_dlc.cli import app
+
+    environment = _write_cli_enrollment(tmp_path)
+    machine = tmp_path / "machine.toml"
+    machine.write_text('schema = 4\n[paths]\nworkspace = "/explicit-machine"\n')
+    project = tmp_path / "project.toml"
+    project.write_text('schema = 4\n[roles]\ntracker = "explicit-project"\n')
+
+    result = CliRunner().invoke(
+        app,
+        ["profile", "show", "--project", str(project), "--machine", str(machine)],
+        env=environment,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["values"]["profile_id"] == "personal-profile"
+    assert payload["values"]["roles"]["knowledge"] == "enrolled-personal"
+    assert payload["values"]["roles"]["tracker"] == "explicit-project"
+    assert payload["values"]["paths"]["workspace"] == "/explicit-machine"
+    assert payload["sources"]["profile_id"] == "personal"
+    assert payload["sources"]["roles.knowledge"] == "personal"
+    assert payload["sources"]["roles.tracker"] == "project"
+    assert payload["sources"]["paths.workspace"] == "machine"
+
+
+def test_explicit_machine_is_forwarded_to_runtime_resolution(monkeypatch, tmp_path):
+    """Would fail if workflow configuration ignored a caller's machine override."""
+    from ai_dlc import cli
+
+    root = tmp_path / "project"
+    machine = tmp_path / "machine.toml"
+    calls = []
+
+    class Resolved:
+        def __init__(self):
+            self.values = {"paths": {"workspace": "/explicit"}}
+
+    def runtime(selected_root, *, machine=None):
+        calls.append((selected_root, machine))
+        return Resolved()
+
+    monkeypatch.setattr(cli, "resolve_runtime", runtime, raising=False)
+
+    assert cli.config_for(root, machine) == {"paths": {"workspace": "/explicit"}}
+    assert calls == [(root, machine)]
+
+
+def test_root_and_machine_doctor_share_enrolled_readiness(monkeypatch, tmp_path):
+    """Would fail if the root doctor used a readiness path different from machine doctor."""
+    from ai_dlc import cli
+
+    calls = []
+
+    class Manager:
+        def doctor(self, root, *, target="local", machine=None):
+            calls.append((root, target, machine))
+            return {"ready": False, "machine_checks": {"available": False}}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager)
+    runner = CliRunner()
+
+    root_result = runner.invoke(cli.app, ["doctor", "--root", str(tmp_path)])
+    machine_result = runner.invoke(cli.app, ["machine", "doctor", "--root", str(tmp_path)])
+
+    assert root_result.exit_code == machine_result.exit_code == 1
+    assert root_result.stdout == machine_result.stdout
+    assert calls == [(tmp_path, "local", None), (tmp_path, "local", None)]
+
+
+def test_root_doctor_help_exposes_root_once():
+    """Would fail if root doctor registered duplicate --root options."""
+    from ai_dlc.cli import app
+
+    result = CliRunner().invoke(app, ["doctor", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.count("--root") == 1
+
+
+def test_explicit_machine_delegates_root_doctor_to_the_manager(monkeypatch, tmp_path):
+    """Would fail if root doctor bypassed enrolled personal resolution for --machine."""
+    from ai_dlc import cli
+
+    root = tmp_path / "project"
+    machine = tmp_path / "machine.toml"
+    calls = []
+
+    class Manager:
+        def doctor(self, selected_root, *, target="local", machine=None):
+            calls.append((selected_root, target, machine))
+            return {"ready": True, "personal": "enrolled"}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager)
+
+    result = CliRunner().invoke(cli.app, ["doctor", "--root", str(root), "--machine", str(machine)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [(root, "local", machine)]
+
+
+def test_explicit_machine_doctor_keeps_the_nonzero_readiness_contract(monkeypatch, tmp_path):
+    """Would fail if an unready effective machine override exited successfully."""
+    from ai_dlc import cli
+
+    class Manager:
+        def doctor(self, root, *, target="local", machine=None):
+            return {"ready": False, "machine": str(machine)}
+
+    monkeypatch.setattr(cli, "MachineManager", Manager)
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["doctor", "--root", str(tmp_path), "--machine", str(tmp_path / "machine.toml")],
+    )
+
+    assert result.exit_code == 1
+    assert '"ready": false' in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 from pathlib import Path
 
+from click import unstyle
 from typer.testing import CliRunner
 
 
@@ -464,7 +465,7 @@ def test_root_doctor_help_exposes_root_once():
     result = CliRunner().invoke(app, ["doctor", "--help"])
 
     assert result.exit_code == 0, result.output
-    assert result.stdout.count("--root") == 1
+    assert unstyle(result.stdout).count("--root") == 1
 
 
 def test_explicit_machine_delegates_root_doctor_to_the_manager(monkeypatch, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,205 @@
+import hashlib
+import tomllib
 from pathlib import Path
 
 import pytest
+
+
+def _write_enrollment(
+    paths, *, content: bytes, machine_id: str = "workstation-01", machine: str = "schema = 4\n"
+) -> None:
+    """Create a real, digest-verified cache and its active enrollment lock."""
+    from ai_dlc.enrollment import EnrollmentLock, write_lock
+
+    profile_id = "personal-profile"
+    resolved_commit = "a" * 40
+    profile_file = "ai-dlc-profile.toml"
+    digest = hashlib.sha256(
+        profile_file.encode("utf-8") + b"\0" + str(len(content)).encode("ascii") + b"\0" + content
+    ).hexdigest()
+    cached_profile = paths.profile_root(profile_id, resolved_commit) / profile_file
+    cached_profile.parent.mkdir(parents=True)
+    cached_profile.write_bytes(content)
+    paths.machine_file(machine_id).parent.mkdir(parents=True)
+    paths.machine_file(machine_id).write_text(machine)
+    write_lock(
+        paths,
+        EnrollmentLock(
+            profile_id=profile_id,
+            source="https://example.test/profiles.git",
+            requested_ref="main",
+            resolved_commit=resolved_commit,
+            content_sha256=digest,
+            machine_id=machine_id,
+        ),
+    )
+
+
+def test_runtime_resolution_uses_enrolled_files_and_fixed_precedence(tmp_path: Path):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+    _write_enrollment(
+        paths,
+        content=(
+            b'schema = 4\nprofile_id = "personal-profile"\n[roles]\ntracker = "personal"\n'
+            b'[preferences]\neditor = "personal"\n'
+        ),
+        machine=('schema = 4\n[preferences]\neditor = "machine"\n[paths]\nworkspace = "/work"\n'),
+    )
+    paths.machine_file("another-machine").parent.mkdir(parents=True, exist_ok=True)
+    paths.machine_file("another-machine").write_text(
+        'schema = 4\n[paths]\nworkspace = "/wrong-machine"\n'
+    )
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text(
+        'schema = 4\n[roles]\ntracker = "project"\n[checks]\nrequired = ["test"]\n'
+    )
+
+    result = resolve_runtime(root, enrollment_paths=paths)
+
+    assert result.values["roles"]["specs"] == "openspec"
+    assert result.values["roles"]["tracker"] == "project"
+    assert result.values["profile_id"] == "personal-profile"
+    assert result.values["preferences"]["editor"] == "machine"
+    assert result.values["paths"]["workspace"] == "/work"
+    assert result.sources["roles.specs"] == "base"
+    assert result.sources["roles.tracker"] == "project"
+    assert result.sources["profile_id"] == "personal"
+    assert result.sources["preferences.editor"] == "machine"
+    assert result.sources["paths.workspace"] == "machine"
+
+
+def test_runtime_explicit_personal_replaces_enrollment_without_reordering_project(tmp_path: Path):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+    _write_enrollment(
+        paths,
+        content=(b'schema = 4\nprofile_id = "personal-profile"\n[roles]\ntracker = "cached"\n'),
+    )
+    explicit_personal = tmp_path / "explicit-personal.toml"
+    explicit_personal.write_text('schema = 4\n[roles]\nknowledge = "explicit"\n')
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text('schema = 4\n[roles]\ntracker = "project"\n')
+
+    result = resolve_runtime(root, personal=explicit_personal, enrollment_paths=paths)
+
+    assert result.values["roles"]["knowledge"] == "explicit"
+    assert result.values["roles"]["tracker"] == "project"
+    assert "profile_id" not in result.values
+    assert result.sources["roles.knowledge"] == "personal"
+    assert result.sources["roles.tracker"] == "project"
+
+
+@pytest.mark.parametrize("cache_state", ["missing", "corrupt"])
+def test_runtime_explicit_personal_does_not_verify_the_replaced_enrolled_cache(
+    tmp_path: Path, cache_state: str
+):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+    _write_enrollment(
+        paths,
+        content=b'schema = 4\nprofile_id = "personal-profile"\n',
+        machine='schema = 4\n[paths]\nworkspace = "/enrolled"\n',
+    )
+    cached_profile = paths.profile_root("personal-profile", "a" * 40) / "ai-dlc-profile.toml"
+    if cache_state == "missing":
+        cached_profile.unlink()
+    else:
+        cached_profile.write_bytes(b"corrupt")
+    explicit_personal = tmp_path / "explicit-personal.toml"
+    explicit_personal.write_text('schema = 4\n[roles]\nknowledge = "explicit"\n')
+
+    result = resolve_runtime(personal=explicit_personal, enrollment_paths=paths)
+
+    assert result.values["roles"]["knowledge"] == "explicit"
+    assert result.values["paths"]["workspace"] == "/enrolled"
+    assert result.sources["roles.knowledge"] == "personal"
+    assert result.sources["paths.workspace"] == "machine"
+
+
+def test_runtime_explicit_machine_replaces_enrollment_and_cannot_weaken_project_checks(
+    tmp_path: Path,
+):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+    _write_enrollment(
+        paths,
+        content=b'schema = 4\nprofile_id = "personal-profile"\n',
+        machine='schema = 4\n[paths]\nworkspace = "/enrolled"\n',
+    )
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text('schema = 4\n[checks]\nrequired = ["test"]\n')
+    explicit_machine = tmp_path / "explicit-machine.toml"
+    explicit_machine.write_text('schema = 4\n[paths]\nworkspace = "/explicit"\n')
+
+    result = resolve_runtime(root, machine=explicit_machine, enrollment_paths=paths)
+
+    assert result.values["paths"]["workspace"] == "/explicit"
+    assert result.sources["paths.workspace"] == "machine"
+
+    explicit_machine.write_text("schema = 4\n[checks]\nrequired = []\n")
+    with pytest.raises(ValueError, match="machine.*checks"):
+        resolve_runtime(root, machine=explicit_machine, enrollment_paths=paths)
+
+
+def test_runtime_without_enrollment_uses_base_and_an_existing_project_only(tmp_path: Path):
+    from ai_dlc.config import resolve_runtime
+
+    root = tmp_path / "project"
+    root.mkdir()
+
+    without_project = resolve_runtime(root, home=tmp_path / "home", environ={})
+    assert without_project.values["roles"]["specs"] == "openspec"
+    assert set(without_project.sources.values()) == {"base"}
+
+    (root / "ai-dlc.toml").write_text('schema = 4\n[roles]\ntracker = "project"\n')
+    with_project = resolve_runtime(root, home=tmp_path / "home", environ={})
+    assert with_project.values["roles"]["tracker"] == "project"
+    assert with_project.sources["roles.tracker"] == "project"
+
+
+@pytest.mark.parametrize("failure", ["missing", "changed", "malformed"])
+def test_runtime_rejects_an_invalid_active_cache(tmp_path: Path, failure: str):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+    content = b'schema = 4\nprofile_id = "personal-profile"\n'
+    _write_enrollment(paths, content=content)
+    cached_profile = paths.profile_root("personal-profile", "a" * 40) / "ai-dlc-profile.toml"
+    if failure == "missing":
+        cached_profile.unlink()
+        expected = RuntimeError
+    elif failure == "changed":
+        cached_profile.write_bytes(content + b'\n[roles]\ntracker = "changed"\n')
+        expected = RuntimeError
+    else:
+        malformed = b"schema = 4\nprofile_id = [\n"
+        cached_profile.write_bytes(malformed)
+        lock = paths.lock_file.read_text().replace(
+            hashlib.sha256(
+                b"ai-dlc-profile.toml\0" + str(len(content)).encode("ascii") + b"\0" + content
+            ).hexdigest(),
+            hashlib.sha256(
+                b"ai-dlc-profile.toml\0" + str(len(malformed)).encode("ascii") + b"\0" + malformed
+            ).hexdigest(),
+        )
+        paths.lock_file.write_text(lock)
+        expected = tomllib.TOMLDecodeError
+
+    with pytest.raises(expected):
+        resolve_runtime(enrollment_paths=paths)
 
 
 def test_retained_named_entry_keeps_original_provenance():
@@ -90,3 +289,219 @@ def test_misplaced_secret_or_unknown_field_rejected():
         resolve_layers([("project", {"schema": 4, "typo": True})])
     with pytest.raises(ValueError, match="credential"):
         resolve_layers([("project", {"schema": 4, "providers": {"linear": {"token": "secret"}}})])
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_tokens", 1024),
+        ("token_count", 10),
+    ],
+)
+def test_benign_numeric_token_settings_remain_schema_4_compatible(field: str, value: int):
+    """Would fail if credential-field detection ignored key structure and value type."""
+    from ai_dlc.config import resolve_layers
+
+    result = resolve_layers(
+        [
+            (
+                "personal",
+                {
+                    "schema": 4,
+                    "providers": {
+                        "language-model": {
+                            field: value,
+                        }
+                    },
+                },
+            )
+        ]
+    )
+
+    assert result.values["providers"]["language-model"] == {
+        field: value,
+    }
+
+
+def test_personal_credential_requirement_and_machine_binding_merge():
+    from ai_dlc.config import resolve_layers
+
+    result = resolve_layers(
+        [
+            (
+                "personal",
+                {
+                    "schema": 4,
+                    "profile_id": "sean-development",
+                    "credentials": {
+                        "linear-sandbox": {
+                            "description": "Linear sandbox access",
+                            "required_by": ["provider.linear-sandbox"],
+                        }
+                    },
+                },
+            ),
+            (
+                "machine",
+                {
+                    "schema": 4,
+                    "credentials": {
+                        "linear-sandbox": {
+                            "source": "environment",
+                            "variable": "LINEAR_SANDBOX_TOKEN",
+                        }
+                    },
+                },
+            ),
+        ]
+    )
+
+    assert result.values["credentials"]["linear-sandbox"] == {
+        "description": "Linear sandbox access",
+        "required_by": ["provider.linear-sandbox"],
+        "source": "environment",
+        "variable": "LINEAR_SANDBOX_TOKEN",
+    }
+    assert result.sources["credentials.linear-sandbox.description"] == "personal"
+    assert result.sources["credentials.linear-sandbox.variable"] == "machine"
+
+
+@pytest.mark.parametrize("layer", ["base", "project", "machine"])
+def test_profile_id_is_limited_to_personal_scope(layer: str):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match="cannot set profile_id"):
+        resolve_layers([(layer, {"schema": 4, "profile_id": "sean-development"})])
+
+
+@pytest.mark.parametrize(
+    ("layer", "entry", "message"),
+    [
+        (
+            "personal",
+            {"description": "Linear access", "required_by": [], "source": "environment"},
+            "personal.*source",
+        ),
+        (
+            "personal",
+            {"description": "Linear access", "required_by": [], "variable": "LINEAR_API_KEY"},
+            "personal.*variable",
+        ),
+        (
+            "machine",
+            {"source": "environment", "variable": "LINEAR_API_KEY", "description": "Linear access"},
+            "machine.*description",
+        ),
+        (
+            "machine",
+            {"source": "environment", "variable": "LINEAR_API_KEY", "required_by": []},
+            "machine.*required_by",
+        ),
+        (
+            "machine",
+            {"source": "file", "variable": "LINEAR_API_KEY"},
+            "machine.*source",
+        ),
+    ],
+)
+def test_credential_entries_reject_invalid_scope_fields(
+    layer: str, entry: dict[str, object], message: str
+):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match=message):
+        resolve_layers([(layer, {"schema": 4, "credentials": {"linear-sandbox": entry}})])
+
+
+@pytest.mark.parametrize(
+    ("layer", "credential_id", "entry", "message"),
+    [
+        (
+            "personal",
+            "Linear-sandbox",
+            {"description": "Linear access", "required_by": []},
+            "credential ID",
+        ),
+        (
+            "machine",
+            "linear_sandbox",
+            {"source": "environment", "variable": "LINEAR_API_KEY"},
+            "credential ID",
+        ),
+        (
+            "machine",
+            "linear-sandbox",
+            {"source": "environment", "variable": "linear-api-key"},
+            "environment variable",
+        ),
+    ],
+)
+def test_credential_identifiers_are_validated(
+    layer: str, credential_id: str, entry: dict[str, object], message: str
+):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match=message):
+        resolve_layers([(layer, {"schema": 4, "credentials": {credential_id: entry}})])
+
+
+def test_credential_values_are_rejected_recursively():
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match="credential value"):
+        resolve_layers(
+            [
+                (
+                    "personal",
+                    {
+                        "schema": 4,
+                        "credentials": {
+                            "linear-sandbox": {
+                                "description": "Linear access",
+                                "required_by": [],
+                                "metadata": {"secret": "not-allowed"},
+                            }
+                        },
+                    },
+                )
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"required_by": []},
+        {"description": "Linear access"},
+        {"description": 1, "required_by": []},
+        {"description": "Linear access", "required_by": ["provider.linear", 1]},
+    ],
+)
+def test_personal_credential_requirements_must_be_complete(entry: dict[str, object]):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match="personal"):
+        resolve_layers([("personal", {"schema": 4, "credentials": {"linear-sandbox": entry}})])
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {"source": "environment"},
+        {"variable": "LINEAR_API_KEY"},
+        {"source": "environment", "variable": "LINEAR_API_KEY", "unexpected": True},
+    ],
+)
+def test_machine_credential_bindings_must_be_complete_and_exact(entry: dict[str, object]):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(ValueError, match="machine"):
+        resolve_layers([("machine", {"schema": 4, "credentials": {"linear-sandbox": entry}})])
+
+
+@pytest.mark.parametrize("credentials", [[], {"linear-sandbox": "not-a-table"}])
+def test_credential_tables_must_be_mappings(credentials: object):
+    from ai_dlc.config import resolve_layers
+
+    with pytest.raises(TypeError, match="credentials"):
+        resolve_layers([("personal", {"schema": 4, "credentials": credentials})])

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,198 @@
+def test_status_reports_presence_without_returning_environment_value(monkeypatch):
+    from ai_dlc.credentials import credential_status
+
+    marker = "fake-value-that-must-not-escape"
+    monkeypatch.setenv("LINEAR_SANDBOX_TOKEN", marker)
+    config = {
+        "credentials": {
+            "linear-sandbox": {
+                "description": "Linear sandbox access",
+                "required_by": ["provider.linear-sandbox"],
+                "source": "environment",
+                "variable": "LINEAR_SANDBOX_TOKEN",
+            }
+        }
+    }
+
+    result = credential_status(config)
+
+    assert result == [
+        {
+            "id": "linear-sandbox",
+            "description": "Linear sandbox access",
+            "required_by": ["provider.linear-sandbox"],
+            "source": "environment",
+            "variable": "LINEAR_SANDBOX_TOKEN",
+            "configured": True,
+            "present": True,
+        }
+    ]
+    assert marker not in repr(result)
+
+
+def test_status_marks_unbound_requirement_as_not_configured_or_present():
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {
+            "credentials": {
+                "linear-sandbox": {
+                    "description": "Linear sandbox access",
+                    "required_by": ["provider.linear-sandbox"],
+                }
+            }
+        },
+        environ={},
+    )
+
+    assert result[0]["configured"] is False
+    assert result[0]["present"] is False
+
+
+def test_status_marks_unset_environment_binding_as_configured_but_not_present():
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {
+            "credentials": {
+                "linear-sandbox": {
+                    "description": "Linear sandbox access",
+                    "required_by": ["provider.linear-sandbox"],
+                    "source": "environment",
+                    "variable": "LINEAR_SANDBOX_TOKEN",
+                }
+            }
+        },
+        environ={},
+    )
+
+    assert result[0]["configured"] is True
+    assert result[0]["present"] is False
+
+
+def test_status_normalizes_uncovered_legacy_provider_token_environment():
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {"providers": {"linear": {"token_env": "LINEAR_API_KEY"}}},
+        environ={"LINEAR_API_KEY": "present"},
+    )
+
+    assert result[0]["id"] == "provider.linear"
+    assert result[0]["required_by"] == ["provider.linear"]
+    assert result[0]["source"] == "environment"
+    assert result[0]["variable"] == "LINEAR_API_KEY"
+    assert result[0]["configured"] is True
+    assert result[0]["present"] is True
+
+
+def test_status_normalizes_the_linear_default_token_environment():
+    """Would fail if default Linear authentication bypassed shared readiness."""
+    from ai_dlc.credentials import credential_status
+
+    absent = credential_status(
+        {"providers": {"linear": {"kind": "linear"}}},
+        environ={},
+    )
+    present = credential_status(
+        {"providers": {"linear": {"kind": "linear"}}},
+        environ={"LINEAR_API_KEY": "present"},
+    )
+
+    assert absent == [
+        {
+            "id": "provider.linear",
+            "description": "Credential for provider linear",
+            "required_by": ["provider.linear"],
+            "source": "environment",
+            "variable": "LINEAR_API_KEY",
+            "configured": True,
+            "present": False,
+        }
+    ]
+    assert present[0]["present"] is True
+
+
+def test_distinct_provider_token_environment_remains_visible_with_logical_requirement():
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {
+            "credentials": {
+                "linear-sandbox": {
+                    "description": "Linear sandbox access",
+                    "required_by": ["provider.linear"],
+                    "source": "environment",
+                    "variable": "LINEAR_SANDBOX_TOKEN",
+                }
+            },
+            "providers": {"linear": {"token_env": "LINEAR_API_KEY"}},
+        },
+        environ={"LINEAR_API_KEY": "provider", "LINEAR_SANDBOX_TOKEN": "logical"},
+    )
+
+    assert [item["id"] for item in result] == ["linear-sandbox", "provider.linear"]
+    assert [item["variable"] for item in result] == [
+        "LINEAR_SANDBOX_TOKEN",
+        "LINEAR_API_KEY",
+    ]
+
+
+def test_matching_provider_token_environment_is_not_reported_twice():
+    """Would fail if one physical credential produced duplicate readiness entries."""
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {
+            "credentials": {
+                "linear-sandbox": {
+                    "description": "Linear sandbox access",
+                    "required_by": ["provider.linear"],
+                    "source": "environment",
+                    "variable": "LINEAR_API_KEY",
+                }
+            },
+            "providers": {"linear": {"kind": "linear"}},
+        },
+        environ={"LINEAR_API_KEY": "present"},
+    )
+
+    assert [item["id"] for item in result] == ["linear-sandbox"]
+
+
+def test_status_uses_supplied_environment_mapping_without_mutating_process_environment(monkeypatch):
+    from ai_dlc.credentials import credential_status
+
+    monkeypatch.delenv("LINEAR_SANDBOX_TOKEN", raising=False)
+    config = {
+        "credentials": {
+            "linear-sandbox": {
+                "description": "Linear sandbox access",
+                "required_by": ["provider.linear-sandbox"],
+                "source": "environment",
+                "variable": "LINEAR_SANDBOX_TOKEN",
+            }
+        }
+    }
+
+    result = credential_status(config, environ={"LINEAR_SANDBOX_TOKEN": "supplied"})
+
+    assert result[0]["present"] is True
+    assert "LINEAR_SANDBOX_TOKEN" not in __import__("os").environ
+
+
+def test_status_is_sorted_by_logical_credential_id():
+    from ai_dlc.credentials import credential_status
+
+    result = credential_status(
+        {
+            "credentials": {
+                "zebra": {"description": "Zebra access", "required_by": []},
+                "alpha": {"description": "Alpha access", "required_by": []},
+            },
+            "providers": {"linear": {"token_env": "LINEAR_API_KEY"}},
+        },
+        environ={},
+    )
+
+    assert [item["id"] for item in result] == ["alpha", "provider.linear", "zebra"]

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,0 +1,270 @@
+import hashlib
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+
+def valid_lock(**overrides):
+    values = {
+        "profile_id": "personal-profile",
+        "source": "https://example.test/profiles.git",
+        "requested_ref": "main",
+        "resolved_commit": "a" * 40,
+        "content_sha256": "b" * 64,
+        "machine_id": "workstation-01",
+        "subdirectory": "profiles/default",
+        "profile_file": "ai-dlc-profile.toml",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_enrollment_paths_use_explicit_xdg_roots(tmp_path):
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(
+        environ={
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "XDG_CACHE_HOME": str(tmp_path / "cache"),
+            "XDG_STATE_HOME": str(tmp_path / "state"),
+        }
+    )
+
+    assert paths.lock_file == tmp_path / "config/ai-dlc/enrollment.toml"
+    assert (
+        paths.machine_file("workstation-01")
+        == tmp_path / "config/ai-dlc/machines/workstation-01.toml"
+    )
+    assert paths.profile_root("personal-profile", "a" * 40) == (
+        tmp_path / "cache/ai-dlc/profiles/personal-profile" / ("a" * 40)
+    )
+    assert paths.state_root == tmp_path / "state/ai-dlc"
+
+
+def test_enrollment_paths_fall_back_to_xdg_locations_under_supplied_home(tmp_path):
+    from ai_dlc.enrollment import EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+
+    assert paths.config_root == tmp_path / ".config/ai-dlc"
+    assert paths.cache_root == tmp_path / ".cache/ai-dlc"
+    assert paths.state_root == tmp_path / ".local/state/ai-dlc"
+
+
+def test_enrollment_lock_accepts_the_supported_pinned_profile_shape():
+    from ai_dlc.enrollment import EnrollmentLock
+
+    lock = EnrollmentLock(**valid_lock(schema=1))
+
+    assert lock.schema == 1
+    assert lock.schema_version == 1
+    assert lock.profile_id == "personal-profile"
+    assert lock.machine_id == "workstation-01"
+    assert lock.subdirectory == "profiles/default"
+    assert lock.profile_file == "ai-dlc-profile.toml"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema", 2),
+        ("profile_id", ""),
+        ("profile_id", "Personal-profile"),
+        ("machine_id", ""),
+        ("machine_id", "Workstation-01"),
+        ("resolved_commit", "A" * 40),
+        ("resolved_commit", "a" * 39),
+        ("content_sha256", "B" * 64),
+        ("content_sha256", "b" * 63),
+        ("subdirectory", "/profiles"),
+        ("subdirectory", "../profiles"),
+        ("subdirectory", "."),
+        ("subdirectory", "profiles//default"),
+        ("profile_file", "/ai-dlc-profile.toml"),
+        ("profile_file", "../ai-dlc-profile.toml"),
+        ("profile_file", "."),
+        ("profile_file", ""),
+        ("profile_file", "profiles//ai-dlc-profile.toml"),
+    ],
+)
+def test_invalid_enrollment_lock_values_fail_before_write(tmp_path, field, value):
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    with pytest.raises(ValidationError):
+        EnrollmentLock(**valid_lock(**{field: value}))
+
+    assert not paths.lock_file.exists()
+
+
+def test_unknown_enrollment_lock_fields_fail_before_write(tmp_path):
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    with pytest.raises(ValidationError):
+        EnrollmentLock(**valid_lock(unexpected="value"))
+
+    assert not paths.lock_file.exists()
+
+
+def test_internal_schema_alias_is_rejected_as_an_unknown_lock_field(tmp_path):
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    with pytest.raises(ValidationError):
+        EnrollmentLock(**valid_lock(schema_version=1))
+
+    assert not paths.lock_file.exists()
+
+
+def test_write_lock_is_parseable_private_and_leaves_no_temporary_final_file(tmp_path):
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, read_lock, write_lock
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    path = write_lock(paths, EnrollmentLock(**valid_lock()))
+
+    assert path == paths.lock_file
+    document = tomllib.loads(path.read_text())
+    assert document["schema"] == 1
+    assert "schema_version" not in document
+    assert document["resolved_commit"] == "a" * 40
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert not list(path.parent.glob(".ai-dlc-*"))
+    assert read_lock(paths) == EnrollmentLock(**valid_lock())
+
+
+def test_enrollment_module_imports_without_warnings_when_warnings_are_errors():
+    result = subprocess.run(
+        [sys.executable, "-W", "error::UserWarning", "-c", "import ai_dlc.enrollment"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_machine_file_is_private_schema_four_and_is_not_replaced(tmp_path):
+    from ai_dlc.enrollment import EnrollmentPaths, ensure_machine_file
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    path = ensure_machine_file(paths, "workstation-01")
+
+    assert tomllib.loads(path.read_text()) == {"schema": 4}
+    assert path.stat().st_mode & 0o777 == 0o600
+    original = b"operator-owned = true\n"
+    path.write_bytes(original)
+    assert ensure_machine_file(paths, "workstation-01") == path
+    assert path.read_bytes() == original
+
+
+def test_machine_file_publish_failure_leaves_no_partial_final_file(tmp_path, monkeypatch):
+    import ai_dlc.files
+    from ai_dlc.enrollment import EnrollmentPaths, ensure_machine_file
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    path = paths.machine_file("workstation-01")
+
+    def fail_publish(staged, final):
+        assert Path(staged).read_text() == "schema = 4\n"
+        assert Path(staged).stat().st_mode & 0o777 == 0o600
+        assert not final.exists()
+        raise OSError("injected publish failure")
+
+    monkeypatch.setattr(ai_dlc.files.os, "link", fail_publish)
+    with pytest.raises(OSError, match="injected publish failure"):
+        ensure_machine_file(paths, "workstation-01")
+
+    assert not path.exists()
+    assert not list(path.parent.glob(".ai-dlc-*"))
+
+
+def test_failed_lock_replacement_preserves_prior_bytes_and_cleans_staging_file(
+    tmp_path, monkeypatch
+):
+    import ai_dlc.files
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, write_lock
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    write_lock(paths, EnrollmentLock(**valid_lock(requested_ref="old")))
+    before = paths.lock_file.read_bytes()
+
+    def fail_replace(staged, final):
+        assert Path(staged).read_text()
+        assert final == paths.lock_file
+        raise OSError("injected replacement failure")
+
+    monkeypatch.setattr(ai_dlc.files.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="injected replacement failure"):
+        write_lock(paths, EnrollmentLock(**valid_lock(requested_ref="new")))
+
+    assert paths.lock_file.read_bytes() == before
+    assert not list(paths.lock_file.parent.glob(".ai-dlc-*"))
+
+
+def test_active_profile_file_combines_only_validated_relative_components(tmp_path):
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, active_profile_file
+
+    paths = EnrollmentPaths.from_environment(home=tmp_path, environ={})
+    lock = EnrollmentLock(**valid_lock(subdirectory="", profile_file="profiles/current.toml"))
+
+    assert active_profile_file(paths, lock) == (
+        tmp_path / ".cache/ai-dlc/profiles/personal-profile" / ("a" * 40) / "profiles/current.toml"
+    )
+
+
+def test_runtime_resolution_does_not_cross_home_or_xdg_enrollment_roots(tmp_path):
+    from ai_dlc.config import resolve_runtime
+    from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, write_lock
+
+    def enroll(paths: EnrollmentPaths, profile_id: str, workspace: str) -> None:
+        content = f'schema = 4\nprofile_id = "{profile_id}"\n'.encode()
+        digest = hashlib.sha256(
+            b"ai-dlc-profile.toml\0" + str(len(content)).encode("ascii") + b"\0" + content
+        ).hexdigest()
+        cached_profile = paths.profile_root(profile_id, "a" * 40) / "ai-dlc-profile.toml"
+        cached_profile.parent.mkdir(parents=True)
+        cached_profile.write_bytes(content)
+        machine_file = paths.machine_file("workstation-01")
+        machine_file.parent.mkdir(parents=True)
+        machine_file.write_text(f'schema = 4\n[paths]\nworkspace = "{workspace}"\n')
+        write_lock(
+            paths,
+            EnrollmentLock(
+                profile_id=profile_id,
+                source="https://example.test/profiles.git",
+                requested_ref="main",
+                resolved_commit="a" * 40,
+                content_sha256=digest,
+                machine_id="workstation-01",
+            ),
+        )
+
+    first_environment = {
+        "XDG_CONFIG_HOME": str(tmp_path / "first-config"),
+        "XDG_CACHE_HOME": str(tmp_path / "first-cache"),
+    }
+    second_environment = {
+        "XDG_CONFIG_HOME": str(tmp_path / "second-config"),
+        "XDG_CACHE_HOME": str(tmp_path / "second-cache"),
+    }
+    first = EnrollmentPaths.from_environment(
+        home=tmp_path / "first-home", environ=first_environment
+    )
+    second = EnrollmentPaths.from_environment(
+        home=tmp_path / "second-home", environ=second_environment
+    )
+    enroll(first, "first-profile", "/first")
+    enroll(second, "second-profile", "/second")
+
+    first_runtime = resolve_runtime(home=tmp_path / "first-home", environ=first_environment)
+    second_runtime = resolve_runtime(home=tmp_path / "second-home", environ=second_environment)
+
+    assert first_runtime.values["profile_id"] == "first-profile"
+    assert first_runtime.values["paths"]["workspace"] == "/first"
+    assert second_runtime.values["profile_id"] == "second-profile"
+    assert second_runtime.values["paths"]["workspace"] == "/second"

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -1,0 +1,1434 @@
+import os
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from ai_dlc import profile_source
+from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths, read_lock, write_lock
+
+PROFILE = """\
+schema = 4
+profile_id = "portable-development"
+
+[modules]
+include = ["core", "codex"]
+
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+
+[[agents.servers]]
+id = "notes"
+command = "notes-mcp"
+args = ["serve"]
+env = ["LINEAR_SANDBOX_TOKEN"]
+"""
+
+LEGACY_PROFILE = PROFILE.replace('profile_id = "portable-development"\n', "")
+
+
+def git(repository: Path, *arguments: str) -> str:
+    """Run one controlled Git command for a disposable profile source."""
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout.strip()
+
+
+def disposable_profile(
+    tmp_path: Path,
+    *,
+    manifest: str = PROFILE,
+    profile_file: str = "ai-dlc-profile.toml",
+) -> tuple[Path, str]:
+    repository = tmp_path / "profile-source"
+    repository.mkdir(parents=True)
+    git(repository, "init", "-b", "main")
+    git(repository, "config", "user.name", "AI-DLC Test")
+    git(repository, "config", "user.email", "ai-dlc@example.test")
+    path = repository / profile_file
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest)
+    git(repository, "add", "--", profile_file)
+    git(repository, "commit", "-m", "add profile")
+    return repository, git(repository, "rev-parse", "HEAD")
+
+
+def manager(tmp_path: Path, environ: dict[str, str] | None = None):
+    from ai_dlc.machine import MachineManager
+
+    home = tmp_path / "home"
+    paths = EnrollmentPaths.from_environment(home=home, environ={})
+    selected_environment = (
+        None if environ is None else {"PATH": os.environ.get("PATH", ""), **environ}
+    )
+    return MachineManager(home=home, environ=selected_environment, paths=paths), paths
+
+
+def fake_git_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[dict[str, str], Path]:
+    real_git = shutil.which("git")
+    assert real_git is not None
+    injected_home = tmp_path / "git-home"
+    injected_home.mkdir(parents=True)
+    injected = {"PATH": os.environ["PATH"], "HOME": str(injected_home)}
+    ambient_bin = tmp_path / "ambient-bin"
+    ambient_bin.mkdir()
+    marker = tmp_path / "ambient-git-invoked"
+    fake_git = ambient_bin / "git"
+    fake_git.write_text('#!/bin/sh\nprintf invoked > "$FAKE_GIT_MARKER"\nexit 97\n')
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", str(ambient_bin))
+    monkeypatch.setenv("FAKE_GIT_MARKER", str(marker))
+    return injected, marker
+
+
+def test_enroll_preview_reports_the_candidate_without_activating_it(tmp_path: Path):
+    """Would fail if preview wrote a lock, machine file, or omitted plan facts."""
+    source, commit = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": "test-value-never-returned"})
+
+    preview = service.enroll(str(source), "portable-development", "laptop")
+
+    assert preview["applied"] is False
+    assert preview["profile"] == {
+        "id": "portable-development",
+        "source": str(source),
+        "requested_ref": "main",
+        "resolved_commit": commit,
+        "content_sha256": "624a0af6afbff788318d5f9d2ae4bc7d3259aa6dda98fa4a84b962fb1b2d045a",
+        "portable": False,
+        "profile_file": "ai-dlc-profile.toml",
+    }
+    assert preview["lock"]["machine_id"] == "laptop"
+    assert preview["modules"] == ["core", "codex"]
+    assert preview["credentials"] == [
+        {
+            "id": "linear-sandbox",
+            "description": "Linear sandbox access",
+            "required_by": ["provider.linear-sandbox"],
+            "configured": False,
+            "present": False,
+        }
+    ]
+    assert preview["user_agents"]["changed"]
+    assert preview["ownership_conflicts"] == []
+    assert not paths.lock_file.exists()
+    assert not paths.machine_file("laptop").exists()
+    assert "test-value-never-returned" not in repr(preview)
+
+
+def test_enroll_apply_creates_a_machine_skeleton_before_activating_an_idempotent_lock(
+    tmp_path: Path,
+):
+    """Would fail if apply activated before creating bindings or changed a stable enrollment."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+
+    applied = service.enroll(str(source), "portable-development", "laptop", apply=True)
+    first_lock = paths.lock_file.read_bytes()
+    repeated = service.enroll(str(source), "portable-development", "laptop", apply=True)
+
+    assert applied["applied"] is True
+    assert tomllib.loads(paths.machine_file("laptop").read_text()) == {"schema": 4}
+    assert read_lock(paths).machine_id == "laptop"
+    assert paths.lock_file.read_bytes() == first_lock
+    assert repeated["idempotent"] is True
+    assert not (paths.config_root.parent.parent / ".claude.json").exists()
+    assert not (paths.config_root.parent.parent / ".codex").exists()
+
+
+def test_enroll_uses_only_the_injected_git_environment(tmp_path: Path, monkeypatch):
+    """Would fail if enrollment launched Git from the ambient PATH."""
+    source, commit = disposable_profile(tmp_path)
+    injected, ambient_marker = fake_git_environment(tmp_path, monkeypatch)
+    service, paths = manager(tmp_path, injected)
+
+    result = service.enroll(str(source), "portable-development", "laptop", apply=True)
+
+    assert result["lock"]["resolved_commit"] == commit
+    assert read_lock(paths).resolved_commit == commit
+    assert (paths.profile_root("portable-development", commit) / "ai-dlc-profile.toml").is_file()
+    assert not ambient_marker.exists()
+
+
+def test_sync_uses_only_the_injected_git_environment(tmp_path: Path, monkeypatch):
+    """Would fail if synchronization launched Git from the ambient PATH."""
+    from ai_dlc.machine import MachineManager
+
+    source, old_commit = disposable_profile(tmp_path)
+    enrolled, paths = manager(tmp_path, {"PATH": os.environ["PATH"]})
+    enrolled.enroll(str(source), "portable-development", "laptop", apply=True)
+    new_commit = advance_profile(source, suffix="python")
+    old_lock = paths.lock_file.read_bytes()
+    injected, ambient_marker = fake_git_environment(tmp_path / "sync-environment", monkeypatch)
+    service = MachineManager(home=enrolled.home, environ=injected, paths=paths)
+
+    result = service.sync()
+
+    assert result["lock"]["resolved_commit"] == new_commit
+    assert result["changes"]["resolved_commit"] == {"from": old_commit, "to": new_commit}
+    assert paths.lock_file.read_bytes() == old_lock
+    assert (
+        paths.profile_root("portable-development", new_commit) / "ai-dlc-profile.toml"
+    ).is_file()
+    assert not ambient_marker.exists()
+
+
+def test_sync_with_an_explicit_empty_environment_never_invokes_ambient_git(
+    tmp_path: Path, monkeypatch
+):
+    """Would fail if empty PATH fell through to ambient Git during synchronization."""
+    from ai_dlc.machine import MachineManager
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    old_lock = paths.lock_file.read_bytes()
+    _, ambient_marker = fake_git_environment(tmp_path / "empty-environment", monkeypatch)
+    isolated = MachineManager(home=service.home, environ={}, paths=paths)
+
+    with pytest.raises(RuntimeError, match="candidate resolution.*active lock preserved"):
+        isolated.sync()
+
+    assert paths.lock_file.read_bytes() == old_lock
+    assert not ambient_marker.exists()
+
+
+def test_enroll_without_an_environment_retains_ambient_git_compatibility(
+    tmp_path: Path, monkeypatch
+):
+    """Would fail if the optional environment changed existing direct behavior."""
+    from ai_dlc.machine import MachineManager
+
+    source, commit = disposable_profile(tmp_path)
+    ambient_path = os.environ["PATH"]
+    monkeypatch.setenv("PATH", ambient_path)
+    home = tmp_path / "ambient-home"
+    paths = EnrollmentPaths.from_environment(home=home, environ={})
+    service = MachineManager(home=home, paths=paths)
+
+    result = service.enroll(str(source), "portable-development", "laptop")
+
+    assert result["lock"]["resolved_commit"] == commit
+
+
+def test_enroll_preview_reports_and_apply_allows_an_explicit_profile_replacement(tmp_path: Path):
+    """Would fail if a different profile silently replaced the active profile."""
+    first_source, _ = disposable_profile(tmp_path / "first")
+    second_source, _ = disposable_profile(
+        tmp_path / "second", manifest=PROFILE.replace("portable-development", "portable-work")
+    )
+    service, paths = manager(tmp_path)
+    service.enroll(str(first_source), "portable-development", "laptop", apply=True)
+
+    preview = service.enroll(str(second_source), "portable-work", "laptop")
+    applied = service.enroll(str(second_source), "portable-work", "laptop", apply=True)
+
+    assert preview["profile_change"] == {
+        "from": "portable-development",
+        "to": "portable-work",
+    }
+    assert applied["profile_change"] == preview["profile_change"]
+    assert read_lock(paths).profile_id == "portable-work"
+
+
+def test_enroll_rejects_a_declared_identity_mismatch_before_writing_active_state(tmp_path: Path):
+    """Would fail if a mismatched source could create or replace an active binding."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+
+    with pytest.raises(ValueError, match="profile_id"):
+        service.enroll(str(source), "other-profile", "laptop", apply=True)
+
+    assert not paths.lock_file.exists()
+    assert not paths.machine_file("laptop").exists()
+
+
+def test_migrate_requires_a_relative_legacy_file_and_preserves_that_source_file(tmp_path: Path):
+    """Would fail if migration accepted an unpinned path or rewrote the user's legacy file."""
+    source, commit = disposable_profile(
+        tmp_path, manifest=LEGACY_PROFILE, profile_file="profiles/personal.toml"
+    )
+    original = (source / "profiles/personal.toml").read_bytes()
+    service, paths = manager(tmp_path)
+
+    with pytest.raises(ValueError, match="relative|normalized"):
+        service.migrate(str(source), "/profiles/personal.toml", "portable-development", "laptop")
+    preview = service.migrate(
+        str(source), "profiles/personal.toml", "portable-development", "laptop"
+    )
+    assert not paths.lock_file.exists()
+    applied = service.migrate(
+        str(source), "profiles/personal.toml", "portable-development", "laptop", apply=True
+    )
+
+    assert preview["applied"] is False
+    assert preview["profile"]["resolved_commit"] == commit
+    assert preview["lock"]["profile_file"] == "profiles/personal.toml"
+    assert applied["applied"] is True
+    assert read_lock(paths).profile_file == "profiles/personal.toml"
+    assert (source / "profiles/personal.toml").read_bytes() == original
+
+
+def test_status_reports_an_actionable_unenrolled_machine(tmp_path: Path):
+    """Would fail if status treated a new machine as an exception instead of a next action."""
+    service, _ = manager(tmp_path)
+
+    status = service.status()
+
+    assert status == {
+        "enrolled": False,
+        "ready": False,
+        "next": "Enroll a profile with ai-dlc machine enroll <source> --profile-id <id> --machine-id <id>.",
+    }
+
+
+def test_status_reports_cached_identity_readiness_and_drift_without_environment_values(
+    tmp_path: Path,
+):
+    """Would fail if status omitted enrollment health or leaked a credential value."""
+    source, commit = disposable_profile(tmp_path)
+    marker = "credential-value-that-must-not-escape"
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": marker})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    paths.machine_file("laptop").write_text(
+        'schema = 4\n[credentials.linear-sandbox]\nsource = "environment"\nvariable = "LINEAR_SANDBOX_TOKEN"\n'
+    )
+
+    status = service.status()
+
+    assert status["enrolled"] is True
+    assert status["ready"] is True
+    assert status["profile"] == {
+        "id": "portable-development",
+        "source": str(source),
+        "requested_ref": "main",
+        "resolved_commit": commit,
+        "portable": False,
+    }
+    assert status["cache"] == "healthy"
+    assert status["machine"] == {
+        "id": "laptop",
+        "path": str(paths.machine_file("laptop")),
+        "exists": True,
+    }
+    assert status["credentials"][0]["id"] == "linear-sandbox"
+    assert status["credentials"][0]["variable"] == "LINEAR_SANDBOX_TOKEN"
+    assert status["credentials"][0]["present"] is True
+    assert status["drift"] == []
+    assert marker not in repr(status)
+
+
+def test_status_reports_missing_machine_and_credential_bindings_as_drift(tmp_path: Path):
+    """Would fail if absent local prerequisites were hidden rather than actionable drift."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    paths.machine_file("laptop").unlink()
+
+    missing_machine = service.status()
+    paths.machine_file("laptop").parent.mkdir(parents=True, exist_ok=True)
+    paths.machine_file("laptop").write_text(
+        'schema = 4\n[credentials.linear-sandbox]\nsource = "environment"\nvariable = "LINEAR_SANDBOX_TOKEN"\n'
+    )
+    missing_credential = service.status()
+
+    assert missing_machine["ready"] is False
+    assert missing_machine["drift"] == ["machine binding is missing"]
+    assert missing_credential["credentials"][0]["id"] == "linear-sandbox"
+    assert missing_credential["credentials"][0]["variable"] == "LINEAR_SANDBOX_TOKEN"
+    assert missing_credential["credentials"][0]["present"] is False
+    assert missing_credential["ready"] is False
+
+
+def test_status_stays_offline_for_corrupt_cache_and_unavailable_source(tmp_path: Path):
+    """Would fail if status fetched a source or treated cache corruption as healthy."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    source.rename(tmp_path / "source-offline")
+
+    offline = service.status()
+    active = read_lock(paths)
+    (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    ).write_text("corrupt\n")
+    corrupt = service.status()
+
+    assert offline["cache"] == "healthy"
+    assert offline["enrolled"] is True
+    assert corrupt["cache"] == "corrupt"
+    assert corrupt["ready"] is False
+    assert "cache is corrupt" in corrupt["drift"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        " https://profile-user:synthetic-credential@example.test/profile.git",
+        "https://profile-user:synthetic-credential@example.test/profile.git ",
+        "https://profile-user:synthetic-credential@example.test/profile.git",
+        "https://profile-user@example.test/synthetic-credential.git",
+        "http://profile-user@example.test/synthetic-credential.git",
+        "ssh://profile-user:synthetic-credential@example.test/profile.git",
+        "https://example.test/profile.git?access_token=synthetic-credential",
+        "https://example.test/profile.git#access_token=synthetic-credential",
+        "https://profile-user%3Asynthetic-credential@example.test/profile.git",
+        "https://profile-user%3Asynthetic-credential%40example.test/profile.git",
+        "https://synthetic-credential／example.test/profile.git",
+        "https:profile-user:synthetic-credential@example.test/profile.git",
+        "https://example.test%3Fsynthetic-credential/profile.git",
+        "https://example.test%23synthetic-credential/profile.git",
+        "https://example.test%2Fsynthetic-credential/profile.git",
+        "https://example.test%EF%BC%8Fsynthetic-credential/profile.git",
+        "https://:443/synthetic-credential.git",
+        "ssh://git@/synthetic-credential.git",
+        "https://example_test/synthetic-credential.git",
+        "https://example.test\\synthetic-credential.git",
+        "https：//profile-user:synthetic-credential@example.test/profile.git",
+        "git:profile-user:synthetic-credential@example.test/profile.git",
+    ],
+)
+def test_enroll_rejects_unsafe_source_before_it_can_reach_local_state_or_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if unsafe URL material reached Git, output, or local enrollment state."""
+    service, paths = manager(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        service.enroll(source, "portable-development", "laptop", apply=True)
+
+    stored_files = [
+        path
+        for root in [paths.config_root, paths.cache_root, paths.state_root]
+        if root.exists()
+        for path in root.rglob("*")
+        if path.is_file()
+    ]
+    assert str(raised.value) == "profile source is invalid"
+    assert "synthetic-credential" not in str(raised.value)
+    assert profile_source.redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert all("synthetic-credential" not in path.read_text() for path in stored_files)
+    assert not paths.lock_file.exists()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("credential-helper::synthetic-credential", id="git-transport-helper"),
+        pytest.param(
+            "https%3a//profile-user:synthetic-credential@example.test/profile.git",
+            id="encoded-scheme-delimiter",
+        ),
+        pytest.param(
+            "https://example.test/profile%2Fsynthetic-credential.git",
+            id="encoded-path-delimiter",
+        ),
+    ],
+)
+def test_machine_rejects_ambiguous_sources_before_git_state_or_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if public enrollment bypassed fail-closed source classification."""
+    service, paths = manager(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        service.enroll(source, "portable-development", "laptop", apply=True)
+
+    status = service.status()
+    stored_files = [
+        path
+        for root in [paths.config_root, paths.cache_root, paths.state_root]
+        if root.exists()
+        for path in root.rglob("*")
+        if path.is_file()
+    ]
+    assert str(raised.value) == "profile source is invalid"
+    assert raised.value.__cause__ is None
+    assert "synthetic-credential" not in repr((raised.value, status))
+    assert profile_source.redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert read_lock(paths) is None
+    assert all(b"synthetic-credential" not in path.read_bytes() for path in stored_files)
+
+
+def test_machine_preview_and_offline_status_classify_username_only_ssh_without_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Would fail if a canonical SSH URL were rejected or previewed differently from status."""
+    source = "ssh://git@example.test/profile.git"
+    service, _ = manager(tmp_path)
+
+    def resolve_without_network(
+        repository: Path, received_source: str, requested_ref: str, *, environ=None
+    ) -> str:
+        del environ
+        assert received_source == source
+        assert requested_ref == "main"
+        (repository / "ai-dlc-profile.toml").write_text(PROFILE)
+        return "a" * 40
+
+    monkeypatch.setattr(profile_source, "_resolve_commit", resolve_without_network)
+
+    preview = service.enroll(source, "portable-development", "laptop")
+    service.enroll(source, "portable-development", "laptop", apply=True)
+    status = service.status()
+
+    assert preview["profile"]["portable"] is True
+    assert status["profile"]["portable"] is True
+
+
+def test_https_source_survives_public_enroll_preview_apply_and_offline_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Would fail if HTTPS metadata were lost outside direct classifier coverage."""
+    source = "https://example.test/portable-profile.git"
+    service, paths = manager(tmp_path)
+    resolution_calls: list[tuple[str, str]] = []
+
+    def resolve_without_network(
+        repository: Path, received_source: str, requested_ref: str, *, environ=None
+    ) -> str:
+        del environ
+        resolution_calls.append((received_source, requested_ref))
+        (repository / "ai-dlc-profile.toml").write_text(PROFILE)
+        return "b" * 40
+
+    monkeypatch.setattr(profile_source, "_resolve_commit", resolve_without_network)
+
+    preview = service.enroll(source, "portable-development", "laptop")
+    applied = service.enroll(source, "portable-development", "laptop", apply=True)
+
+    def unexpected_online_resolution(*_arguments: object) -> str:
+        raise AssertionError("offline status contacted the HTTPS source")
+
+    monkeypatch.setattr(profile_source, "_resolve_commit", unexpected_online_resolution)
+    status = service.status()
+
+    assert resolution_calls == [(source, "main"), (source, "main")]
+    assert preview["profile"]["source"] == source
+    assert preview["profile"]["portable"] is True
+    assert preview["profile"]["resolved_commit"] == "b" * 40
+    assert preview["modules"] == ["core", "codex"]
+    assert preview["lock"]["source"] == source
+    assert applied["lock"]["source"] == source
+    assert read_lock(paths).source == source
+    assert (paths.profile_root("portable-development", "b" * 40) / "ai-dlc-profile.toml").is_file()
+    assert status["cache"] == "healthy"
+    assert status["profile"]["source"] == source
+    assert status["profile"]["portable"] is True
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_git_source"),
+    [
+        ("https://example.test/portable-profile.git", None),
+        ("ssh://git@example.test/portable-profile.git", None),
+        ("git@example.test:portable-profile.git", None),
+        ("file:///profiles/portable-profile.git", None),
+        ("local-profile", "resolved-local-profile"),
+    ],
+)
+def test_public_enroll_classifies_a_source_before_resolving_only_local_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    expected_git_source: str | None,
+):
+    """Would fail if a URL-shaped cwd path could replace the external Git source."""
+    monkeypatch.chdir(tmp_path)
+    source_path = Path(source)
+    source_path.mkdir(parents=True)
+    service, _ = manager(tmp_path)
+    received_sources: list[str] = []
+
+    def resolve_without_network(
+        repository: Path, received_source: str, requested_ref: str, *, environ=None
+    ) -> str:
+        del environ
+        received_sources.append(received_source)
+        assert requested_ref == "main"
+        (repository / "ai-dlc-profile.toml").write_text(PROFILE)
+        return "c" * 40
+
+    monkeypatch.setattr(profile_source, "_resolve_commit", resolve_without_network)
+
+    service.enroll(source, "portable-development", "laptop")
+
+    expected = (
+        str((tmp_path / "local-profile").resolve())
+        if expected_git_source == "resolved-local-profile"
+        else source
+    )
+    assert received_sources == [expected]
+
+
+@pytest.mark.parametrize(
+    "unsafe_source",
+    [
+        "https:synthetic-credential@example.test/profile.git",
+        " https://profile-user:synthetic-credential@example.test/profile.git",
+        "https://:443/synthetic-credential.git",
+        "credential-helper::synthetic-credential",
+        "https%3A//profile-user:synthetic-credential@example.test/profile.git",
+    ],
+)
+def test_status_redacts_an_unsafe_legacy_lock_source(tmp_path: Path, unsafe_source: str):
+    """Would fail if status returned a credential from an old unsafe enrollment lock."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    active = read_lock(paths)
+    write_lock(
+        paths,
+        active.model_copy(update={"source": unsafe_source}),
+    )
+
+    status = service.status()
+
+    assert "synthetic-credential" not in repr(status)
+    assert status["profile"]["source"] == "<redacted profile source>"
+
+
+def test_enroll_validates_preview_before_replacing_the_active_lock(tmp_path: Path):
+    """Would fail if an invalid module structure activated a candidate before result assembly."""
+    active_source, _ = disposable_profile(tmp_path / "active")
+    invalid_source, _ = disposable_profile(
+        tmp_path / "invalid",
+        manifest=PROFILE.replace(
+            '[modules]\ninclude = ["core", "codex"]\n', 'modules = ["core"]\n'
+        ),
+    )
+    service, paths = manager(tmp_path)
+    service.enroll(str(active_source), "portable-development", "laptop", apply=True)
+    original_lock = paths.lock_file.read_bytes()
+
+    with pytest.raises((TypeError, ValueError), match="modules"):
+        service.enroll(str(invalid_source), "portable-development", "new-laptop", apply=True)
+
+    assert paths.lock_file.read_bytes() == original_lock
+    assert not paths.machine_file("new-laptop").exists()
+
+
+def test_enroll_rejects_invalid_agent_configuration_without_activating_it(tmp_path: Path):
+    """Would fail if candidate validation errors were misreported as ownership conflicts."""
+    active_source, _ = disposable_profile(tmp_path / "active")
+    invalid_source, _ = disposable_profile(
+        tmp_path / "invalid",
+        manifest=PROFILE.replace('env = ["LINEAR_SANDBOX_TOKEN"]', 'env = ["literal-value"]'),
+    )
+    service, paths = manager(tmp_path)
+    service.enroll(str(active_source), "portable-development", "laptop", apply=True)
+    original_lock = paths.lock_file.read_bytes()
+
+    with pytest.raises(ValueError, match="literal values"):
+        service.enroll(str(invalid_source), "portable-development", "new-laptop", apply=True)
+
+    assert paths.lock_file.read_bytes() == original_lock
+    assert not paths.machine_file("new-laptop").exists()
+
+
+@pytest.mark.parametrize(
+    ("source", "portable"),
+    [
+        ("local", False),
+        ("file", False),
+        ("https://example.test/profile.git", True),
+        ("ssh://git@example.test/profile.git", True),
+        ("git@example.test:profile.git", True),
+    ],
+)
+def test_preview_and_offline_status_use_the_same_source_portability_classification(
+    tmp_path: Path,
+    source: str,
+    portable: bool,
+):
+    """Would fail if status reclassified a persisted source differently from enrollment."""
+    repository, _ = disposable_profile(tmp_path / "source")
+    selected_source = {
+        "local": str(repository),
+        "file": repository.as_uri(),
+    }.get(source, source)
+    service, paths = manager(tmp_path)
+    preview_source = selected_source if source in {"local", "file"} else str(repository)
+    preview = service.enroll(preview_source, "portable-development", "laptop")
+    lock = preview["lock"].copy()
+    lock["source"] = selected_source
+    service.enroll(preview_source, "portable-development", "laptop", apply=True)
+    write_lock(paths, EnrollmentLock.model_validate(lock))
+    repository.rename(tmp_path / "source-offline")
+
+    status = service.status()
+
+    if source in {"local", "file"}:
+        assert preview["profile"]["portable"] is portable
+    assert status["profile"]["portable"] is portable
+
+
+def test_enroll_preview_uses_the_provisioning_default_module_when_modules_are_omitted(
+    tmp_path: Path,
+):
+    """Would fail if enrollment preview disagreed with provisioning's default module selection."""
+    source, _ = disposable_profile(
+        tmp_path,
+        manifest=PROFILE.replace('[modules]\ninclude = ["core", "codex"]\n\n', ""),
+    )
+    service, _ = manager(tmp_path)
+
+    preview = service.enroll(str(source), "portable-development", "laptop")
+
+    assert preview["modules"] == ["core"]
+
+
+def configure_active_machine(paths: EnrollmentPaths) -> Path:
+    active = read_lock(paths)
+    machine_file = paths.machine_file(active.machine_id)
+    machine_file.write_text(
+        'schema = 4\n[credentials.linear-sandbox]\nsource = "environment"\nvariable = "LINEAR_SANDBOX_TOKEN"\n'
+    )
+    return machine_file
+
+
+def advance_profile(repository: Path, *, suffix: str = "codex") -> str:
+    profile = repository / "ai-dlc-profile.toml"
+    profile.write_text(PROFILE.replace('["core", "codex"]', f'["core", "{suffix}"]'))
+    git(repository, "add", "--", "ai-dlc-profile.toml")
+    git(repository, "commit", "-m", "advance profile")
+    return git(repository, "rev-parse", "HEAD")
+
+
+@pytest.mark.parametrize(
+    ("operation", "provision_name"),
+    [("plan", "machine_plan"), ("apply", "machine_apply")],
+)
+def test_explicit_profile_replaces_only_the_personal_scope_for_reconciliation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str, provision_name: str
+):
+    """Would fail if an explicit profile discarded the active machine binding."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    replacement = tmp_path / "replacement.toml"
+    replacement.write_text(PROFILE)
+    calls = []
+
+    def boundary(profile: Path, **kwargs) -> dict[str, object]:
+        calls.append((profile, kwargs))
+        return {"ready": True, "commands": []}
+
+    monkeypatch.setattr(provision, provision_name, boundary)
+
+    result = getattr(service, operation)(profile=replacement)
+
+    assert calls == [
+        (
+            replacement,
+            {
+                "headless": False,
+                "home": service.home,
+                "machine": machine_file,
+                "environ": service.environ,
+            },
+        )
+    ]
+    assert result["lock"]["machine_id"] == "laptop"
+
+
+def test_explicit_machine_replaces_only_the_machine_scope_for_doctor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if doctor lost the verified enrolled personal profile for --machine."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": "present"})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    configure_active_machine(paths)
+    active = read_lock(paths)
+    active_profile = (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    )
+    replacement = tmp_path / "replacement-machine.toml"
+    replacement.write_text('schema = 4\n[paths]\nworkspace = "/replacement"\n')
+    calls = []
+
+    def boundary(root: Path, **kwargs) -> dict[str, object]:
+        calls.append((root, kwargs))
+        return {"ready": True, "credentials": []}
+
+    monkeypatch.setattr(provision, "doctor", boundary)
+
+    result = service.doctor(tmp_path, machine=replacement)
+
+    assert calls == [
+        (
+            tmp_path,
+            {
+                "target": "local",
+                "personal": active_profile,
+                "machine": replacement,
+                "home": service.home,
+                "environ": service.environ,
+            },
+        )
+    ]
+    assert result["ready"] is True
+
+
+def test_doctor_without_enrollment_forwards_an_explicit_machine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if explicit-machine doctor discarded legacy no-profile compatibility."""
+    from ai_dlc import provision
+
+    service, _ = manager(tmp_path)
+    machine = tmp_path / "machine.toml"
+    machine.write_text("schema = 4\n")
+    calls = []
+
+    def boundary(root: Path, **kwargs) -> dict[str, object]:
+        calls.append((root, kwargs))
+        return {"ready": True, "credentials": []}
+
+    monkeypatch.setattr(provision, "doctor", boundary)
+
+    result = service.doctor(tmp_path, machine=machine)
+
+    assert calls == [
+        (
+            tmp_path,
+            {
+                "target": "local",
+                "personal": None,
+                "machine": machine,
+                "home": service.home,
+                "environ": service.environ,
+            },
+        )
+    ]
+    assert result["ready"] is True
+    assert result["machine_status"]["machine"] == {
+        "path": str(machine),
+        "exists": True,
+        "override": True,
+    }
+
+
+def test_explicit_machine_replaces_degraded_enrolled_machine_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if drift on the replaced enrolled machine still blocked doctor readiness."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": "present"})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    paths.machine_file("laptop").unlink()
+    machine = tmp_path / "replacement-machine.toml"
+    machine.write_text("schema = 4\n")
+    monkeypatch.setattr(provision, "doctor", lambda *args, **kwargs: {"ready": True})
+
+    result = service.doctor(tmp_path, machine=machine)
+
+    assert result["ready"] is True
+    assert result["machine_status"]["ready"] is True
+    assert result["machine_status"]["machine"]["path"] == str(machine)
+    assert result["machine_checks"] == {"available": True, "unavailable": []}
+
+
+def test_explicit_machine_does_not_hide_a_corrupt_active_personal_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if machine replacement made a corrupt unreplaced personal cache ready."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    active = read_lock(paths)
+    (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    ).write_text("corrupt\n")
+    machine = tmp_path / "replacement-machine.toml"
+    machine.write_text("schema = 4\n")
+    monkeypatch.setattr(provision, "doctor", lambda *args, **kwargs: {"ready": True})
+
+    result = service.doctor(tmp_path, machine=machine)
+
+    assert result["ready"] is False
+    assert result["machine_status"]["ready"] is False
+    assert result["machine_status"]["machine"] == {
+        "path": str(machine),
+        "exists": True,
+        "override": True,
+    }
+    assert result["machine_checks"] == {
+        "available": False,
+        "unavailable": ["verified profile cache", "complete user-agent readiness"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("content", "error"),
+    [(None, FileNotFoundError), ("schema = [\n", tomllib.TOMLDecodeError)],
+)
+def test_doctor_rejects_an_invalid_or_missing_explicit_machine_file(
+    tmp_path: Path, content: str | None, error: type[Exception]
+):
+    """Would fail if an explicit bad machine binding were silently ignored."""
+    service, _ = manager(tmp_path)
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text("schema = 4\n")
+    machine = tmp_path / "machine.toml"
+    if content is not None:
+        machine.write_text(content)
+
+    with pytest.raises(error):
+        service.doctor(root, machine=machine)
+
+
+def test_plan_uses_only_the_verified_active_profile_and_machine_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if plan fetched, selected another binding, or changed local state."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    active = read_lock(paths)
+    active_profile = (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    )
+    before = {
+        path: path.read_bytes()
+        for root in [paths.config_root, paths.cache_root]
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+    calls: list[tuple[Path, bool, Path | None, Path | None, object]] = []
+
+    def plan_boundary(
+        profile: Path,
+        headless: bool = False,
+        system: str | None = None,
+        architecture: str | None = None,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del system, architecture
+        calls.append((profile, headless, home, machine, environ))
+        return {"commands": [], "agent_configuration": {"applied": False}}
+
+    monkeypatch.setattr(provision, "machine_plan", plan_boundary)
+
+    result = service.plan(headless=True)
+
+    after = {
+        path: path.read_bytes()
+        for root in [paths.config_root, paths.cache_root]
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+    assert calls == [(active_profile, True, service.home, machine_file, service.environ)]
+    assert result["lock"]["resolved_commit"] == active.resolved_commit
+    assert result["commands"] == []
+    assert after == before
+
+
+def test_apply_returns_active_lock_identity_with_the_reconciliation_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if apply omitted lock identity or reconciled without the active binding."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    active = read_lock(paths)
+    active_profile = (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    )
+    calls: list[tuple[Path, bool, Path | None, Path | None, object]] = []
+
+    def apply_boundary(
+        profile: Path,
+        headless: bool = False,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        calls.append((profile, headless, home, machine, environ))
+        return {"ready": True, "applied": [["mise", "install"]]}
+
+    monkeypatch.setattr(provision, "machine_apply", apply_boundary)
+
+    result = service.apply(headless=True)
+
+    assert calls == [(active_profile, True, service.home, machine_file, service.environ)]
+    assert result["lock"] == active.model_dump(by_alias=True)
+    assert result["ready"] is True
+    assert result["applied"] == [["mise", "install"]]
+
+
+def test_sync_preview_fetches_a_moved_ref_and_preserves_lock_and_clients(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if preview activated a candidate or rewrote an agent client."""
+    from ai_dlc import provision
+
+    source, old_commit = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": "present"})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    old_lock = paths.lock_file.read_bytes()
+    new_commit = advance_profile(source, suffix="python")
+    calls: list[tuple[Path, Path | None, object]] = []
+
+    def plan_boundary(
+        profile: Path,
+        headless: bool = False,
+        system: str | None = None,
+        architecture: str | None = None,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del headless, system, architecture, home
+        calls.append((profile, machine, environ))
+        return {"credentials": [{"id": "linear-sandbox", "present": True}]}
+
+    monkeypatch.setattr(provision, "machine_plan", plan_boundary)
+
+    result = service.sync()
+
+    assert calls == [
+        (
+            paths.profile_root("portable-development", new_commit) / "ai-dlc-profile.toml",
+            machine_file,
+            service.environ,
+        )
+    ]
+    assert result["applied"] is False
+    assert result["idempotent"] is False
+    assert result["changes"]["resolved_commit"] == {"from": old_commit, "to": new_commit}
+    assert '-include = ["core", "codex"]' in result["changes"]["configuration"]
+    assert '+include = ["core", "python"]' in result["changes"]["configuration"]
+    assert result["readiness"]["ready"] is True
+    assert paths.lock_file.read_bytes() == old_lock
+    assert not (service.home / ".claude.json").exists()
+    assert not (service.home / ".codex").exists()
+
+
+def test_sync_apply_reconciles_candidate_before_activating_its_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if sync activated the new commit before candidate reconciliation."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": "present"})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    old_lock = paths.lock_file.read_bytes()
+    new_commit = advance_profile(source, suffix="python")
+    events: list[str] = []
+
+    def plan_boundary(*args, **kwargs) -> dict[str, object]:
+        del args, kwargs
+        assert paths.lock_file.read_bytes() == old_lock
+        events.append("plan")
+        return {"credentials": [{"id": "linear-sandbox", "present": True}]}
+
+    def apply_boundary(
+        profile: Path,
+        headless: bool = False,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del headless, home
+        assert profile == (
+            paths.profile_root("portable-development", new_commit) / "ai-dlc-profile.toml"
+        )
+        assert machine == machine_file
+        assert environ is service.environ
+        assert paths.lock_file.read_bytes() == old_lock
+        events.append("apply")
+        return {"ready": True, "applied": [["mise", "install"]]}
+
+    monkeypatch.setattr(provision, "machine_plan", plan_boundary)
+    monkeypatch.setattr(provision, "machine_apply", apply_boundary)
+
+    result = service.sync(apply=True)
+
+    assert events == ["plan", "apply"]
+    assert read_lock(paths).resolved_commit == new_commit
+    assert result["applied"] is True
+    assert result["reconciliation"]["ready"] is True
+
+
+def test_failed_sync_reconciliation_preserves_lock_and_labels_package_side_effects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if a partial package operation activated or obscured the candidate."""
+    from ai_dlc import provision
+
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    configure_active_machine(paths)
+    old_lock = paths.lock_file.read_bytes()
+    new_commit = advance_profile(source, suffix="python")
+    partial = tmp_path / "package-side-effect"
+    monkeypatch.setattr(provision, "machine_plan", lambda *args, **kwargs: {"credentials": []})
+
+    def fail_after_package_side_effect(*args, **kwargs):
+        del args, kwargs
+        partial.write_text("installed before failure")
+        raise RuntimeError("package manager failed")
+
+    monkeypatch.setattr(provision, "machine_apply", fail_after_package_side_effect)
+
+    with pytest.raises(RuntimeError, match="reconciliation.*package-side effects.*partial"):
+        service.sync(apply=True)
+
+    assert paths.lock_file.read_bytes() == old_lock
+    assert partial.is_file()
+    assert (
+        paths.profile_root("portable-development", new_commit) / "ai-dlc-profile.toml"
+    ).is_file()
+
+
+@pytest.mark.parametrize("failure", ["invalid", "corrupt", "fetch"])
+def test_sync_candidate_failures_preserve_the_active_lock(tmp_path: Path, failure: str):
+    """Would fail if validation, cache integrity, or fetch failure changed active state."""
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    configure_active_machine(paths)
+    old_lock = paths.lock_file.read_bytes()
+    active = read_lock(paths)
+    if failure == "invalid":
+        profile = source / "ai-dlc-profile.toml"
+        profile.write_text(PROFILE + '\napi_key = "synthetic-secret"\n')
+        git(source, "add", "--", "ai-dlc-profile.toml")
+        git(source, "commit", "-m", "invalid candidate")
+    elif failure == "corrupt":
+        (
+            paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+        ).write_text("corrupt\n")
+    else:
+        source.rename(tmp_path / "source-unavailable")
+
+    with pytest.raises((RuntimeError, ValueError)):
+        service.sync()
+
+    assert paths.lock_file.read_bytes() == old_lock
+
+
+def test_sync_to_the_active_commit_is_idempotent_without_reconciliation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if an unchanged source caused package or client side effects."""
+    from ai_dlc import provision
+
+    source, commit = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path)
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    configure_active_machine(paths)
+    old_lock = paths.lock_file.read_bytes()
+
+    def unexpected(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("idempotent sync reconciled an unchanged commit")
+
+    monkeypatch.setattr(provision, "machine_plan", unexpected)
+    monkeypatch.setattr(provision, "machine_apply", unexpected)
+
+    result = service.sync(apply=True)
+
+    assert result["idempotent"] is True
+    assert result["lock"]["resolved_commit"] == commit
+    assert paths.lock_file.read_bytes() == old_lock
+
+
+def test_machine_doctor_combines_status_and_shared_checks_without_environment_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if doctor skipped active layers or exposed a credential value."""
+    from ai_dlc import provision
+
+    marker = "credential-value-that-must-not-escape-doctor"
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": marker})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    machine_file = configure_active_machine(paths)
+    active = read_lock(paths)
+    active_profile = (
+        paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+    )
+    root = tmp_path / "project"
+    root.mkdir()
+    calls: list[dict[str, object]] = []
+
+    def doctor_boundary(
+        selected_root: Path,
+        target: str = "local",
+        machine: Path | None = None,
+        personal: Path | None = None,
+        home: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        calls.append(
+            {
+                "root": selected_root,
+                "target": target,
+                "machine": machine,
+                "personal": personal,
+                "home": home,
+                "environ": environ,
+            }
+        )
+        return {
+            "ready": True,
+            "runtime_drift": [],
+            "user_agents": {"clean": True, "changed": [], "applied": False},
+            "signins": [],
+            "credentials": [{"id": "linear-sandbox", "present": True}],
+            "provider_health": [{"provider": "linear-sandbox", "ready": True}],
+        }
+
+    monkeypatch.setattr(provision, "doctor", doctor_boundary)
+
+    result = service.doctor(root, target="container")
+
+    assert calls == [
+        {
+            "root": root,
+            "target": "container",
+            "machine": machine_file,
+            "personal": active_profile,
+            "home": service.home,
+            "environ": service.environ,
+        }
+    ]
+    assert result["ready"] is True
+    assert result["machine_status"]["cache"] == "healthy"
+    assert result["runtime_drift"] == []
+    assert result["user_agents"]["clean"] is True
+    assert result["credentials"][0]["present"] is True
+    assert result["provider_health"][0]["ready"] is True
+    assert marker not in repr(result)
+
+
+@pytest.mark.parametrize("condition", ["unenrolled", "missing-machine", "corrupt-cache"])
+def test_machine_doctor_returns_partial_diagnostics_when_enrollment_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, condition: str
+):
+    """Would fail if a known enrollment problem made doctor raise or fetch."""
+    from ai_dlc import provision
+
+    service, paths = manager(tmp_path)
+    if condition != "unenrolled":
+        source, _ = disposable_profile(tmp_path)
+        service.enroll(str(source), "portable-development", "laptop", apply=True)
+        if condition == "missing-machine":
+            paths.machine_file("laptop").unlink()
+        else:
+            active = read_lock(paths)
+            (
+                paths.profile_root(active.profile_id, active.resolved_commit) / active.profile_file
+            ).write_text("corrupt\n")
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text("schema = 4\n")
+    calls: list[tuple[Path | None, Path | None]] = []
+
+    def doctor_boundary(
+        selected_root: Path,
+        target: str = "local",
+        machine: Path | None = None,
+        personal: Path | None = None,
+        home: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del selected_root, target, home, environ
+        calls.append((personal, machine))
+        return {"ready": True, "runtime_drift": [], "credentials": []}
+
+    def unexpected_fetch(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("doctor contacted the profile source")
+
+    monkeypatch.setattr(provision, "doctor", doctor_boundary)
+    monkeypatch.setattr(profile_source, "_resolve_commit", unexpected_fetch)
+
+    result = service.doctor(root)
+
+    assert result["ready"] is False
+    assert result["machine_status"]["ready"] is False
+    assert result["machine_checks"]["available"] is False
+    assert result["machine_checks"]["unavailable"]
+    assert len(calls) == 1
+    if condition == "unenrolled":
+        assert calls == [(None, None)]
+    elif condition == "missing-machine":
+        assert calls[0][0] is not None
+        assert calls[0][1] is None
+    else:
+        assert calls[0][0] is None
+
+
+def test_manager_injected_environment_flows_through_status_plan_apply_and_doctor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if any lifecycle method consulted ambient credential state."""
+    from ai_dlc import provision
+    from ai_dlc.config import resolve_files
+    from ai_dlc.credentials import credential_status
+
+    marker = "injected-machine-credential"
+    monkeypatch.delenv("LINEAR_SANDBOX_TOKEN", raising=False)
+    source, _ = disposable_profile(tmp_path)
+    service, paths = manager(tmp_path, {"LINEAR_SANDBOX_TOKEN": marker})
+    service.enroll(str(source), "portable-development", "laptop", apply=True)
+    configure_active_machine(paths)
+    received_environments: list[object] = []
+
+    def readiness(profile: Path, machine: Path | None, environ) -> list[dict[str, object]]:
+        received_environments.append(environ)
+        return credential_status(
+            resolve_files(personal=profile, machine=machine).values,
+            environ=environ,
+        )
+
+    def plan_boundary(
+        profile: Path,
+        headless: bool = False,
+        system: str | None = None,
+        architecture: str | None = None,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del headless, system, architecture, home
+        return {"credentials": readiness(profile, machine, environ)}
+
+    def apply_boundary(
+        profile: Path,
+        headless: bool = False,
+        home: Path | None = None,
+        machine: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del headless, home
+        return {"credentials": readiness(profile, machine, environ), "applied": []}
+
+    def doctor_boundary(
+        root: Path,
+        target: str = "local",
+        machine: Path | None = None,
+        personal: Path | None = None,
+        home: Path | None = None,
+        environ=None,
+    ) -> dict[str, object]:
+        del root, target, home
+        return {
+            "ready": True,
+            "credentials": readiness(personal, machine, environ),
+            "provider_health": [{"provider": "linear-sandbox", "ready": True}],
+        }
+
+    monkeypatch.setattr(provision, "machine_plan", plan_boundary)
+    monkeypatch.setattr(provision, "machine_apply", apply_boundary)
+    monkeypatch.setattr(provision, "doctor", doctor_boundary)
+
+    status = service.status()
+    plan = service.plan()
+    applied = service.apply()
+    diagnosed = service.doctor(tmp_path)
+
+    assert status["credentials"][0]["present"] is True
+    assert plan["credentials"][0]["present"] is True
+    assert applied["credentials"][0]["present"] is True
+    assert diagnosed["credentials"][0]["present"] is True
+    assert diagnosed["provider_health"][0]["ready"] is True
+    assert received_environments == [service.environ, service.environ, service.environ]
+    assert marker not in repr((status, plan, applied, diagnosed))
+
+
+def test_legacy_default_manifest_migration_syncs_unchanged_and_after_ref_movement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Would fail if legacy sync guessed identity compatibility from the filename."""
+    from ai_dlc import provision
+
+    source, first_commit = disposable_profile(tmp_path, manifest=LEGACY_PROFILE)
+    service, paths = manager(tmp_path)
+    service.migrate(
+        str(source),
+        "ai-dlc-profile.toml",
+        "portable-development",
+        "laptop",
+        apply=True,
+    )
+    unchanged = service.sync()
+    profile = source / "ai-dlc-profile.toml"
+    profile.write_text(LEGACY_PROFILE.replace('["core", "codex"]', '["core", "python"]'))
+    git(source, "add", "--", "ai-dlc-profile.toml")
+    git(source, "commit", "-m", "advance legacy profile")
+    second_commit = git(source, "rev-parse", "HEAD")
+    monkeypatch.setattr(provision, "machine_plan", lambda *args, **kwargs: {"credentials": []})
+    monkeypatch.setattr(
+        provision,
+        "machine_apply",
+        lambda *args, **kwargs: {"ready": True, "applied": []},
+    )
+
+    moved = service.sync(apply=True)
+
+    assert unchanged["idempotent"] is True
+    assert unchanged["lock"]["resolved_commit"] == first_commit
+    assert unchanged["lock"]["profile_file"] == "ai-dlc-profile.toml"
+    assert moved["applied"] is True
+    assert moved["lock"]["resolved_commit"] == second_commit
+    assert moved["lock"]["profile_file"] == "ai-dlc-profile.toml"
+    assert read_lock(paths).resolved_commit == second_commit

--- a/tests/test_machine_integration.py
+++ b/tests/test_machine_integration.py
@@ -1,0 +1,320 @@
+import json
+import os
+import shutil
+import stat
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ai_dlc.config import digest, resolve_files
+from ai_dlc.enrollment import EnrollmentPaths, read_lock
+from ai_dlc.machine import MachineManager
+from ai_dlc.profile_source import verify_cached_profile
+
+PROFILE = """\
+schema = 4
+profile_id = "portable-development"
+
+[modules]
+include = ["python"]
+
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+
+[[agents.servers]]
+id = "notes"
+command = "notes-mcp"
+args = ["serve"]
+env = ["NOTES_ACCESS_TOKEN"]
+"""
+
+UPDATED_PROFILE = PROFILE.replace('include = ["python"]', 'include = ["node"]')
+LEGACY_PROFILE = PROFILE.replace('profile_id = "portable-development"\n\n', "")
+SENTINEL_A = "synthetic-machine-a-value-never-persist"
+SENTINEL_B = "synthetic-machine-b-value-never-persist"
+
+
+def _machine(
+    tmp_path: Path,
+    name: str,
+    git_environment: dict[str, str],
+    credentials: dict[str, str] | None = None,
+):
+    root = tmp_path / name
+    home = root / "home"
+    tools = root / "tools"
+    home.mkdir(parents=True)
+    tools.mkdir(parents=True)
+    for tool in ["brew", "mise", "notes-mcp"]:
+        path = tools / tool
+        path.write_text("test executable; execution is replaced at the process boundary\n")
+        path.chmod(0o700)
+    environment = {
+        **git_environment,
+        "PATH": f"{git_environment['PATH']}:{tools}",
+        "HOME": str(home),
+        "XDG_CONFIG_HOME": str(root / "xdg" / "config"),
+        "XDG_CACHE_HOME": str(root / "xdg" / "cache"),
+        "XDG_STATE_HOME": str(root / "xdg" / "state"),
+        "XDG_DATA_HOME": str(root / "xdg" / "data"),
+        "AI_DLC_BOOTSTRAP_HOME": str(root / "bootstrap"),
+        "SHELL": "/bin/zsh",
+        **(credentials or {}),
+    }
+    paths = EnrollmentPaths.from_environment(home=home, environ=environment)
+    return root, MachineManager(home=home, environ=environment, paths=paths), paths
+
+
+def _bind(paths: EnrollmentPaths, machine_id: str, variable: str) -> None:
+    paths.machine_file(machine_id).write_text(
+        "schema = 4\n"
+        "[credentials.linear-sandbox]\n"
+        'source = "environment"\n'
+        f'variable = "{variable}"\n'
+    )
+
+
+def _replace_external_execution(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> None:
+    import ai_dlc.provision
+
+    def execute(*args, **kwargs):
+        del args, kwargs
+        if fail:
+            raise RuntimeError("synthetic package manager failure")
+
+    monkeypatch.setattr(ai_dlc.provision, "subprocess", SimpleNamespace(run=execute))
+
+
+def _returned_without_sentinels(results: list[object]) -> None:
+    serialized = json.dumps(results, sort_keys=True, default=str)
+    assert SENTINEL_A not in serialized
+    assert SENTINEL_B not in serialized
+
+
+def _trees_without_sentinels(*roots: Path) -> None:
+    for root in roots:
+        for path in root.rglob("*"):
+            if path.is_file():
+                content = path.read_bytes()
+                assert SENTINEL_A.encode() not in content, path
+                assert SENTINEL_B.encode() not in content, path
+
+
+def _tree_snapshot(root: Path) -> dict[str, tuple[object, ...]]:
+    snapshot: dict[str, tuple[object, ...]] = {}
+    for path in [root, *sorted(root.rglob("*"))]:
+        relative = "." if path == root else path.relative_to(root).as_posix()
+        metadata = path.lstat()
+        mode = stat.S_IMODE(metadata.st_mode)
+        if stat.S_ISLNK(metadata.st_mode):
+            snapshot[relative] = ("symlink", mode, os.readlink(path))
+        elif stat.S_ISDIR(metadata.st_mode):
+            snapshot[relative] = ("directory", mode)
+        elif stat.S_ISREG(metadata.st_mode):
+            snapshot[relative] = ("file", mode, path.read_bytes())
+        else:
+            snapshot[relative] = ("other", mode, metadata.st_rdev)
+    return snapshot
+
+
+def test_two_isolated_machines_share_a_profile_but_not_bindings_or_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, local_git_profile
+):
+    """Would fail on shared XDG state, lost provenance, online planning, or secret persistence."""
+    source = local_git_profile(PROFILE)
+    root_a, machine_a, paths_a = _machine(
+        tmp_path,
+        "machine-a",
+        source.environment,
+        {"LINEAR_A_TOKEN": SENTINEL_A, "NOTES_ACCESS_TOKEN": SENTINEL_A},
+    )
+    root_b, machine_b, paths_b = _machine(
+        tmp_path,
+        "machine-b",
+        source.environment,
+        {"LINEAR_B_TOKEN": SENTINEL_B, "NOTES_ACCESS_TOKEN": SENTINEL_B},
+    )
+    results: list[object] = []
+
+    results.append(machine_a.enroll(source.source, "portable-development", "machine-a", apply=True))
+    results.append(machine_b.enroll(source.source, "portable-development", "machine-b", apply=True))
+    _bind(paths_a, "machine-a", "LINEAR_A_TOKEN")
+    _bind(paths_b, "machine-b", "LINEAR_B_TOKEN")
+
+    lock_a = read_lock(paths_a)
+    lock_b = read_lock(paths_b)
+    assert lock_a is not None and lock_b is not None
+    assert lock_a.resolved_commit == lock_b.resolved_commit == source.commit
+    assert lock_a.content_sha256 == lock_b.content_sha256
+    assert results[0]["profile"]["portable"] is True
+    assert results[1]["profile"]["portable"] is True
+    profile_a = verify_cached_profile(lock_a, paths_a)
+    profile_b = verify_cached_profile(lock_b, paths_b)
+    resolved_a = resolve_files(personal=profile_a, machine=paths_a.machine_file("machine-a"))
+    resolved_b = resolve_files(personal=profile_b, machine=paths_b.machine_file("machine-b"))
+    assert digest(tomllib.loads(profile_a.read_text())) == digest(
+        tomllib.loads(profile_b.read_text())
+    )
+    assert resolved_a.sources["profile_id"] == resolved_b.sources["profile_id"] == "personal"
+    assert resolved_a.sources["credentials.linear-sandbox.variable"] == "machine"
+    assert resolved_b.sources["credentials.linear-sandbox.variable"] == "machine"
+    assert resolved_a.values["credentials"]["linear-sandbox"]["variable"] == "LINEAR_A_TOKEN"
+    assert resolved_b.values["credentials"]["linear-sandbox"]["variable"] == "LINEAR_B_TOKEN"
+
+    before_a = _tree_snapshot(root_a)
+    plan_a = machine_a.plan()
+    assert _tree_snapshot(root_a) == before_a
+    before_b = _tree_snapshot(root_b)
+    plan_b = machine_b.plan()
+    assert _tree_snapshot(root_b) == before_b
+    results.extend([plan_a, plan_b])
+
+    _replace_external_execution(monkeypatch)
+    results.extend([machine_a.apply(), machine_b.apply()])
+    for machine, variable in [(machine_a, "LINEAR_A_TOKEN"), (machine_b, "LINEAR_B_TOKEN")]:
+        claude = json.loads((machine.home / ".claude.json").read_text())
+        codex = tomllib.loads((machine.home / ".codex/config.toml").read_text())
+        assert claude["mcpServers"]["notes"]["env"] == {
+            "NOTES_ACCESS_TOKEN": "${NOTES_ACCESS_TOKEN}"
+        }
+        assert codex["mcp_servers"]["notes"]["env_vars"] == ["NOTES_ACCESS_TOKEN"]
+        status = machine.status()
+        results.append(status)
+        assert status["credentials"][0]["variable"] == variable
+
+    shutil.rmtree(source.repository)
+    results.extend([machine_a.status(), machine_b.status(), machine_a.plan(), machine_b.plan()])
+    assert results[-4]["cache"] == results[-3]["cache"] == "healthy"
+    _returned_without_sentinels(results)
+    _trees_without_sentinels(root_a, root_b)
+
+
+def test_failed_sync_keeps_the_old_lock_and_retry_activates_the_cached_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, local_git_profile
+):
+    """Would fail if reconciliation activated early or a cached candidate could not be retried."""
+    source = local_git_profile(PROFILE)
+    _, machine, paths = _machine(
+        tmp_path,
+        "transaction-machine",
+        source.environment,
+        {"LINEAR_A_TOKEN": SENTINEL_A},
+    )
+    machine.enroll(source.source, "portable-development", "machine-a", apply=True)
+    _bind(paths, "machine-a", "LINEAR_A_TOKEN")
+    old_lock = paths.lock_file.read_bytes()
+    new_commit = source.advance(UPDATED_PROFILE)
+
+    _replace_external_execution(monkeypatch)
+    preview = machine.sync()
+    assert preview["lock"]["resolved_commit"] == new_commit
+    assert paths.lock_file.read_bytes() == old_lock
+
+    _replace_external_execution(monkeypatch, fail=True)
+    with pytest.raises(RuntimeError, match="reconciliation.*active lock preserved") as failure:
+        machine.sync(apply=True)
+    assert paths.lock_file.read_bytes() == old_lock
+
+    _replace_external_execution(monkeypatch)
+    applied = machine.sync(apply=True)
+    assert read_lock(paths).resolved_commit == new_commit
+    assert applied["reconciliation"]["agent_configuration"]["applied"] is True
+    _returned_without_sentinels([preview, str(failure.value), applied])
+
+
+def test_cache_tampering_is_scoped_to_one_machine(tmp_path: Path, local_git_profile):
+    """Would fail if cache integrity were skipped or machine caches were shared."""
+    source = local_git_profile(PROFILE)
+    _, machine_a, paths_a = _machine(tmp_path, "cache-machine-a", source.environment)
+    _, machine_b, _ = _machine(tmp_path, "cache-machine-b", source.environment)
+    machine_a.enroll(source.source, "portable-development", "machine-a", apply=True)
+    machine_b.enroll(source.source, "portable-development", "machine-b", apply=True)
+    lock_a = read_lock(paths_a)
+    assert lock_a is not None
+    verify_cached_profile(lock_a, paths_a).write_text("tampered\n")
+
+    status_a = machine_a.status()
+    status_b = machine_b.status()
+
+    assert status_a["cache"] == "corrupt"
+    assert status_a["ready"] is False
+    assert status_b["cache"] == "healthy"
+
+
+def test_authored_mcp_collision_blocks_sync_before_lock_change_and_preserves_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, local_git_profile
+):
+    """Would fail if sync overwrote an authored MCP server or changed its lock first."""
+    source = local_git_profile(PROFILE)
+    _, machine, paths = _machine(tmp_path, "ownership-machine", source.environment)
+    machine.enroll(source.source, "portable-development", "machine-a", apply=True)
+    _bind(paths, "machine-a", "LINEAR_A_TOKEN")
+    authored_path = machine.home / ".claude.json"
+    authored_path.write_text(json.dumps({"mcpServers": {"notes": {"command": "authored"}}}))
+    authored = authored_path.read_bytes()
+    old_lock = paths.lock_file.read_bytes()
+    source.advance(UPDATED_PROFILE)
+    _replace_external_execution(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="candidate planning.*active lock preserved"):
+        machine.sync(apply=True)
+
+    assert paths.lock_file.read_bytes() == old_lock
+    assert authored_path.read_bytes() == authored
+
+
+def test_fetch_failure_keeps_offline_status_healthy_and_reports_the_sync_step(
+    tmp_path: Path, local_git_profile
+):
+    """Would fail if sync invalidated the active cache or hid the failed source step."""
+    source = local_git_profile(PROFILE)
+    _, machine, paths = _machine(
+        tmp_path,
+        "offline-machine",
+        source.environment,
+        {"LINEAR_A_TOKEN": SENTINEL_A},
+    )
+    machine.enroll(source.source, "portable-development", "machine-a", apply=True)
+    _bind(paths, "machine-a", "LINEAR_A_TOKEN")
+    old_lock = paths.lock_file.read_bytes()
+    shutil.rmtree(source.repository)
+
+    status = machine.status()
+    with pytest.raises(
+        RuntimeError, match="candidate resolution.*active lock preserved"
+    ) as failure:
+        machine.sync()
+
+    assert status["cache"] == "healthy"
+    assert status["ready"] is True
+    assert paths.lock_file.read_bytes() == old_lock
+    _returned_without_sentinels([status, str(failure.value)])
+
+
+def test_legacy_profile_file_migrates_and_syncs_for_the_compatibility_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, local_git_profile
+):
+    """Would fail if sync forgot an explicitly selected legacy profile path or identity mode."""
+    source = local_git_profile(LEGACY_PROFILE, profile_file="profiles/personal.toml")
+    _, machine, paths = _machine(tmp_path, "legacy-machine", source.environment)
+    enrolled = machine.migrate(
+        source.source,
+        "profiles/personal.toml",
+        "portable-development",
+        "legacy-machine",
+        apply=True,
+    )
+    _bind(paths, "legacy-machine", "LINEAR_A_TOKEN")
+    second_commit = source.advance(
+        LEGACY_PROFILE.replace('include = ["python"]', 'include = ["node"]')
+    )
+    _replace_external_execution(monkeypatch)
+
+    synced = machine.sync(apply=True)
+
+    assert enrolled["lock"]["profile_file"] == "profiles/personal.toml"
+    assert synced["lock"]["profile_file"] == "profiles/personal.toml"
+    assert read_lock(paths).resolved_commit == second_commit

--- a/tests/test_profile_source.py
+++ b/tests/test_profile_source.py
@@ -1,0 +1,835 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ai_dlc import profile_source
+from ai_dlc.enrollment import EnrollmentLock, EnrollmentPaths
+from ai_dlc.profile_source import (
+    ProfileCandidate,
+    redact_source,
+    resolve_profile_source,
+    source_portability,
+    verify_cached_profile,
+)
+
+NORMAL_MANIFEST = """\
+schema = 4
+profile_id = "test-development"
+
+[modules]
+include = ["core"]
+
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+"""
+
+
+def git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=10,
+    )
+    return result.stdout.strip()
+
+
+def disposable_git_repository(
+    tmp_path: Path,
+    *,
+    manifest: str = NORMAL_MANIFEST,
+    profile_path: str = "ai-dlc-profile.toml",
+) -> tuple[Path, str]:
+    repository = tmp_path / "source"
+    repository.mkdir()
+    git(repository, "init", "-b", "main")
+    git(repository, "config", "user.name", "AI-DLC Test")
+    git(repository, "config", "user.email", "ai-dlc@example.test")
+    path = repository / profile_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(manifest)
+    git(repository, "add", "--", profile_path)
+    git(repository, "commit", "-m", "add profile")
+    return repository, git(repository, "rev-parse", "HEAD")
+
+
+def enrollment_paths(tmp_path: Path) -> EnrollmentPaths:
+    return EnrollmentPaths.from_environment(home=tmp_path / "home", environ={})
+
+
+def lock_for(candidate: ProfileCandidate) -> EnrollmentLock:
+    return EnrollmentLock(
+        profile_id=candidate.profile_id,
+        source=candidate.source,
+        requested_ref=candidate.requested_ref,
+        resolved_commit=candidate.resolved_commit,
+        content_sha256=candidate.content_sha256,
+        machine_id="test-machine",
+        subdirectory=candidate.subdirectory,
+        profile_file=candidate.profile_file,
+    )
+
+
+def cache_snapshot(paths: EnrollmentPaths) -> dict[str, bytes]:
+    if not paths.cache_root.exists():
+        return {}
+    return {
+        path.relative_to(paths.cache_root).as_posix(): path.read_bytes()
+        for path in paths.cache_root.rglob("*")
+        if path.is_file()
+    }
+
+
+def test_resolution_pins_exact_commit_and_has_deterministic_bundle_digest(tmp_path: Path):
+    repository, commit = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert candidate.resolved_commit == commit
+    assert len(candidate.resolved_commit) == 40
+    assert candidate.content_sha256 == (
+        "3bc76f2b624ea58774b9980efd8c775f7fe07b597c9e356a766e6b4dbdca5b7c"
+    )
+    assert len(candidate.content_sha256) == 64
+    assert candidate.cache_root == paths.profile_root("test-development", commit)
+
+
+def test_cache_contains_only_declared_profile_without_git_or_unrelated_files(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    (repository / "unrelated.txt").write_text("do not cache\n")
+    (repository / "nested").mkdir()
+    (repository / "nested/also-unrelated.txt").write_text("do not cache\n")
+    git(repository, "add", "--", "unrelated.txt", "nested/also-unrelated.txt")
+    git(repository, "commit", "-m", "add unrelated files")
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    entries = sorted(
+        path.relative_to(candidate.cache_root).as_posix()
+        for path in candidate.cache_root.rglob("*")
+    )
+    assert entries == ["ai-dlc-profile.toml"]
+    assert not (candidate.cache_root / ".git").exists()
+    assert (candidate.cache_root / "ai-dlc-profile.toml").read_text() == NORMAL_MANIFEST
+
+
+def test_relative_subdirectory_selects_only_its_declared_profile(tmp_path: Path):
+    repository, commit = disposable_git_repository(
+        tmp_path, profile_path="profiles/development/ai-dlc-profile.toml"
+    )
+    (repository / "profiles/development/notes.txt").write_text("not part of the profile\n")
+    git(repository, "add", "--", "profiles/development/notes.txt")
+    git(repository, "commit", "-m", "add nearby unrelated file")
+    commit = git(repository, "rev-parse", "HEAD")
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(
+        str(repository),
+        "test-development",
+        "main",
+        paths,
+        subdirectory="profiles/development",
+    )
+
+    assert candidate.resolved_commit == commit
+    assert candidate.subdirectory == "profiles/development"
+    assert (candidate.cache_root / "profiles/development/ai-dlc-profile.toml").is_file()
+    assert not (candidate.cache_root / "profiles/development/notes.txt").exists()
+
+
+@pytest.mark.parametrize(
+    ("subdirectory", "profile_file"),
+    [
+        ("../outside", "ai-dlc-profile.toml"),
+        ("profiles/./development", "ai-dlc-profile.toml"),
+        ("", "../ai-dlc-profile.toml"),
+        ("", "/tmp/ai-dlc-profile.toml"),
+    ],
+)
+def test_relative_profile_selection_cannot_escape_or_use_unnormalized_paths(
+    tmp_path: Path, subdirectory: str, profile_file: str
+):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="relative|normalized"):
+        resolve_profile_source(
+            str(repository),
+            "test-development",
+            "main",
+            paths,
+            subdirectory=subdirectory,
+            profile_file=profile_file,
+        )
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_declared_profile_id_must_match_requested_identity(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="profile_id"):
+        resolve_profile_source(str(repository), "other-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_normal_resolution_requires_declared_profile_identity(tmp_path: Path):
+    repository, _ = disposable_git_repository(
+        tmp_path, manifest=NORMAL_MANIFEST.replace('profile_id = "test-development"\n', "")
+    )
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="profile_id"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_legacy_resolution_accepts_explicit_profile_file_without_identity(tmp_path: Path):
+    legacy = NORMAL_MANIFEST.replace('profile_id = "test-development"\n', "")
+    repository, commit = disposable_git_repository(
+        tmp_path, manifest=legacy, profile_path="legacy/profile.toml"
+    )
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(
+        str(repository),
+        "test-development",
+        "main",
+        paths,
+        profile_file="legacy/profile.toml",
+        allow_legacy_identity=True,
+    )
+
+    assert candidate.profile_id == "test-development"
+    assert candidate.resolved_commit == commit
+    assert (candidate.cache_root / "legacy/profile.toml").read_text() == legacy
+
+
+def test_legacy_resolution_still_rejects_a_different_declared_identity(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="profile_id"):
+        resolve_profile_source(
+            str(repository),
+            "other-development",
+            "main",
+            paths,
+            allow_legacy_identity=True,
+        )
+
+
+def test_secret_shaped_profile_field_is_rejected_before_cache_activation(tmp_path: Path):
+    secret_manifest = NORMAL_MANIFEST + '\n[providers.linear]\ntoken = "must-not-persist"\n'
+    repository, _ = disposable_git_repository(tmp_path, manifest=secret_manifest)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="credential value"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "tokens",
+        "api_token",
+        "api_tokens",
+        "api-token",
+        "api-tokens",
+        "apiToken",
+        "apiTokens",
+        "APIToken",
+        "access_token",
+        "access-token",
+        "client_secret",
+        "client-secret",
+        "clientSecret",
+        "accessToken",
+        "private_key",
+    ],
+)
+def test_common_secret_shaped_fields_are_rejected_before_cache_activation(
+    tmp_path: Path, field: str
+):
+    manifest = NORMAL_MANIFEST + f'\n[providers.custom]\n"{field}" = "synthetic-value"\n'
+    repository, _ = disposable_git_repository(tmp_path, manifest=manifest)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="credential value"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize("field", ["max_tokens", "token_count"])
+def test_token_metric_fields_reject_literal_strings_before_cache_activation(
+    tmp_path: Path, field: str
+):
+    manifest = NORMAL_MANIFEST + f'\n[providers.custom]\n{field} = "synthetic-value"\n'
+    repository, _ = disposable_git_repository(tmp_path, manifest=manifest)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="credential value"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_benign_secret_field_lookalikes_can_be_cached(tmp_path: Path):
+    manifest = (
+        NORMAL_MANIFEST
+        + """
+[providers.custom]
+tokenizer = "words"
+secretary = "person"
+monkey = "animal"
+keyboard_layout = "dvorak"
+api_version = "v1"
+max_tokens = 1024
+token_count = 10
+"""
+    )
+    repository, _ = disposable_git_repository(tmp_path, manifest=manifest)
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert (candidate.cache_root / candidate.profile_file).read_text() == manifest
+
+
+def test_explicit_environment_reference_fields_can_be_cached(tmp_path: Path):
+    manifest = (
+        NORMAL_MANIFEST
+        + """
+[providers.custom]
+token_env = "CUSTOM_TOKEN"
+api_token_env = "CUSTOM_API_TOKEN"
+client_secret_env = "CUSTOM_CLIENT_SECRET"
+bearer_token_env_var = "CUSTOM_BEARER_TOKEN"
+"""
+    )
+    repository, _ = disposable_git_repository(tmp_path, manifest=manifest)
+    paths = enrollment_paths(tmp_path)
+
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert (candidate.cache_root / candidate.profile_file).read_text() == manifest
+
+
+def test_environment_reference_field_rejects_a_literal_value_before_cache_activation(
+    tmp_path: Path,
+):
+    manifest = NORMAL_MANIFEST + (
+        '\n[providers.custom]\napi_token_env = "synthetic-value-not-an-env-name"\n'
+    )
+    repository, _ = disposable_git_repository(tmp_path, manifest=manifest)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="credential value"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_symlink_profile_path_is_rejected(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path, profile_path="actual.toml")
+    os.symlink("actual.toml", repository / "ai-dlc-profile.toml")
+    git(repository, "add", "--", "ai-dlc-profile.toml")
+    git(repository, "commit", "-m", "add profile symlink")
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="symlink"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_non_regular_profile_path_is_rejected(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    (repository / "profile-directory").mkdir()
+    (repository / "profile-directory/tracked.txt").write_text("tracked so the directory exists\n")
+    git(repository, "add", "--", "profile-directory/tracked.txt")
+    git(repository, "commit", "-m", "add profile directory")
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(ValueError, match="regular file"):
+        resolve_profile_source(
+            str(repository),
+            "test-development",
+            "main",
+            paths,
+            profile_file="profile-directory",
+        )
+
+    assert cache_snapshot(paths) == {}
+
+
+def test_second_resolution_reuses_existing_byte_identical_cache(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    first = resolve_profile_source(str(repository), "test-development", "main", paths)
+    cached_file = first.cache_root / first.profile_file
+    original_bytes = cached_file.read_bytes()
+    original_inode = cached_file.stat().st_ino
+
+    second = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert second == first
+    assert cached_file.read_bytes() == original_bytes
+    assert cached_file.stat().st_ino == original_inode
+
+
+def test_changed_existing_cache_is_reported_as_corrupt_and_not_replaced(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+    cached_file = candidate.cache_root / candidate.profile_file
+    cached_file.write_bytes(b"corrupt cache bytes\n")
+
+    with pytest.raises(RuntimeError, match="corrupt"):
+        resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert cached_file.read_bytes() == b"corrupt cache bytes\n"
+
+
+def test_moved_branch_creates_new_cache_and_preserves_old_verified_cache(tmp_path: Path):
+    repository, old_commit = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    old_candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+    old_file = old_candidate.cache_root / old_candidate.profile_file
+    old_bytes = old_file.read_bytes()
+
+    (repository / "ai-dlc-profile.toml").write_text(NORMAL_MANIFEST + "\n# moved branch\n")
+    git(repository, "add", "--", "ai-dlc-profile.toml")
+    git(repository, "commit", "-m", "move branch")
+    new_commit = git(repository, "rev-parse", "HEAD")
+    new_candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+
+    assert old_candidate.resolved_commit == old_commit
+    assert new_candidate.resolved_commit == new_commit
+    assert new_candidate.resolved_commit != old_candidate.resolved_commit
+    assert new_candidate.cache_root != old_candidate.cache_root
+    assert old_file.read_bytes() == old_bytes
+    assert verify_cached_profile(lock_for(old_candidate), paths) == old_file
+
+
+@pytest.mark.parametrize("requested_ref", ["missing-ref", "shared"])
+def test_invalid_or_ambiguous_ref_does_not_change_existing_cache(
+    tmp_path: Path, requested_ref: str
+):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    resolve_profile_source(str(repository), "test-development", "main", paths)
+    before = cache_snapshot(paths)
+    if requested_ref == "shared":
+        git(repository, "branch", "shared")
+        git(repository, "tag", "shared")
+
+    with pytest.raises(RuntimeError, match="Git"):
+        resolve_profile_source(str(repository), "test-development", requested_ref, paths)
+
+    assert cache_snapshot(paths) == before
+    assert not list(paths.cache_root.parent.glob(".ai-dlc-profile-*"))
+
+
+@pytest.mark.parametrize("requested_ref_kind", ["head", "commit"])
+def test_unadvertised_pseudoref_or_commit_is_rejected_without_changing_cache(
+    tmp_path: Path, requested_ref_kind: str
+):
+    repository, commit = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    resolve_profile_source(str(repository), "test-development", "main", paths)
+    before = cache_snapshot(paths)
+    requested_ref = "HEAD" if requested_ref_kind == "head" else commit
+
+    with pytest.raises(RuntimeError, match="Git"):
+        resolve_profile_source(str(repository), "test-development", requested_ref, paths)
+
+    assert cache_snapshot(paths) == before
+    assert not list(paths.cache_root.parent.glob(".ai-dlc-profile-*"))
+
+
+@pytest.mark.parametrize("requested_ref", ["refs/heads/*", "main:refs/heads/copied"])
+def test_wildcard_or_refspec_requested_ref_is_rejected(tmp_path: Path, requested_ref: str):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+
+    with pytest.raises(RuntimeError, match="Git"):
+        resolve_profile_source(str(repository), "test-development", requested_ref, paths)
+
+    assert cache_snapshot(paths) == {}
+    assert not list(paths.cache_root.parent.glob(".ai-dlc-profile-*"))
+
+
+def test_requested_ref_is_passed_as_data_without_shell_interpolation(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    sentinel = tmp_path / "interpolated"
+
+    with pytest.raises(RuntimeError, match="Git"):
+        resolve_profile_source(
+            str(repository),
+            "test-development",
+            f"main;touch {sentinel}",
+            paths,
+        )
+
+    assert not sentinel.exists()
+    assert cache_snapshot(paths) == {}
+
+
+def test_cached_profile_verifies_offline_after_source_disappears(tmp_path: Path):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    candidate = resolve_profile_source(str(repository), "test-development", "main", paths)
+    expected = candidate.cache_root / candidate.profile_file
+    repository.rename(tmp_path / "source-unavailable")
+
+    assert verify_cached_profile(lock_for(candidate), paths) == expected
+
+
+@pytest.mark.parametrize("as_file_url", [False, True])
+def test_local_repository_sources_are_nonportable(tmp_path: Path, as_file_url: bool):
+    repository, _ = disposable_git_repository(tmp_path)
+    paths = enrollment_paths(tmp_path)
+    source = repository.as_uri() if as_file_url else str(repository)
+
+    candidate = resolve_profile_source(source, "test-development", "main", paths)
+
+    assert candidate.source == source
+    assert candidate.portable is False
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "local?literal",
+        "local#literal",
+        "local literal",
+    ],
+)
+def test_literal_query_and_fragment_characters_remain_valid_in_local_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
+):
+    repository, _ = disposable_git_repository(tmp_path)
+    named_source = tmp_path / name
+    repository.rename(named_source)
+    paths = enrollment_paths(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    candidate = resolve_profile_source(name, "test-development", "main", paths)
+
+    assert candidate.portable is False
+
+
+@pytest.mark.parametrize(
+    ("source", "portable"),
+    [
+        ("/profiles/local", False),
+        ("file:///profiles/local", False),
+        ("https://example.test/profile.git", True),
+        ("ssh://git@example.test/profile.git", True),
+        ("git@example.test:profile.git", True),
+        ("C:/profiles/local", False),
+    ],
+)
+def test_source_portability_classifies_supported_source_syntax(source: str, portable: bool):
+    assert source_portability(source) is portable
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "https:profile-user:synthetic-credential@example.test/profile.git",
+        "https://example.test%3Fsynthetic-credential/profile.git",
+        "https://example.test%EF%BC%8Fsynthetic-credential/profile.git",
+    ],
+)
+def test_malformed_or_encoded_url_syntax_is_nonportable_and_redacted(source: str):
+    assert source_portability(source) is False
+    assert redact_source(source) == "<redacted profile source>"
+
+
+def test_cleartext_http_source_fails_closed_before_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    paths = enrollment_paths(tmp_path)
+    source = "http://example.test/profile.git"
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object, **keywords: object) -> str:
+        git_calls.append((*arguments, keywords))
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert source_portability(source) is False
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("credential-helper::synthetic-credential", id="git-transport-helper"),
+        pytest.param(
+            "https%3A//profile-user:synthetic-credential@example.test/profile.git",
+            id="encoded-colon-upper",
+        ),
+        pytest.param(
+            "https%3a//profile-user:synthetic-credential@example.test/profile.git",
+            id="encoded-colon-lower",
+        ),
+        pytest.param(
+            "https://example.test/profile%2Fsynthetic-credential.git",
+            id="encoded-slash-upper",
+        ),
+        pytest.param(
+            "ssh://git@example.test/profile%2fsynthetic-credential.git",
+            id="encoded-slash-lower",
+        ),
+        pytest.param("example.test:profile%40synthetic-credential.git", id="encoded-at"),
+        pytest.param("./profile%3Fsynthetic-credential.git", id="encoded-query"),
+        pytest.param("./profile%23synthetic-credential.git", id="encoded-fragment"),
+        pytest.param(
+            "https://example.test/profile%26synthetic-credential.git",
+            id="encoded-sub-delimiter",
+        ),
+    ],
+)
+def test_ambiguous_source_syntax_fails_closed_before_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if ambiguous Git/URI syntax bypassed the shared classifier."""
+    paths = enrollment_paths(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert raised.value.__cause__ is None
+    assert "synthetic-credential" not in str(raised.value)
+    assert source_portability(source) is False
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "",
+        " https://profile-user:synthetic-credential@example.test/profile.git",
+        "\thttps://profile-user:synthetic-credential@example.test/profile.git",
+        "\nhttps://profile-user:synthetic-credential@example.test/profile.git",
+        "https://profile-user:synthetic-credential@example.test/profile.git ",
+        "https://profile-user:synthetic-credential@example.test/profile.git\n",
+        "https：//profile-user:synthetic-credential@example.test/profile.git",
+        "https://example.test/profile\u2060synthetic-credential.git",
+        "https://example.test/profile\u202esynthetic-credential.git",
+        "local\u2028synthetic-credential",
+        "local\u1680synthetic-credential",
+        "local\ue000synthetic-credential",
+        "local\ufdd0synthetic-credential",
+    ],
+)
+def test_source_lexical_safety_is_enforced_before_git_or_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if unsafe source text fell through to a local or SCP Git source."""
+    paths = enrollment_paths(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert raised.value.__cause__ is None
+    assert "synthetic-credential" not in str(raised.value)
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize("codepoint", [*range(32), 127])
+def test_every_ascii_control_and_del_is_rejected_before_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    codepoint: int,
+):
+    """Would fail if URL parsing erased or tolerated an ASCII control character."""
+    paths = enrollment_paths(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+    source = f"https://example.test/profile{chr(codepoint)}synthetic-credential.git"
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert "synthetic-credential" not in str(raised.value)
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "https://:443/synthetic-credential.git",
+        "ssh://git@/synthetic-credential.git",
+        "http://profile-user@example.test/synthetic-credential.git",
+        "https://profile-user@example.test/synthetic-credential.git",
+        "file://profile-user@localhost/synthetic-credential.git",
+        "https://example_test/synthetic-credential.git",
+        "https://-example.test/synthetic-credential.git",
+        "https://example..test/synthetic-credential.git",
+        "https://exam!ple.test/synthetic-credential.git",
+        "https://example.test\\synthetic-credential.git",
+        "https://example.test/path\\synthetic-credential.git",
+        "https://example.test:/synthetic-credential.git",
+        "https://example.test:0/synthetic-credential.git",
+        "https://example.test:65536/synthetic-credential.git",
+        "git://example.test/synthetic-credential.git",
+        "nested/git://example.test/synthetic-credential.git",
+    ],
+)
+def test_malformed_or_unsupported_urls_fail_closed_before_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if noncanonical URL authority or scheme syntax reached Git."""
+    paths = enrollment_paths(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert "synthetic-credential" not in str(raised.value)
+    assert source_portability(source) is False
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "@example.test:synthetic-credential.git",
+        "git@:synthetic-credential.git",
+        "example.test:",
+        "git:profile-user:synthetic-credential@example.test/profile.git",
+        "profile-user:synthetic-credential@example.test/profile.git",
+        "example_test:synthetic-credential.git",
+    ],
+)
+def test_malformed_scp_intent_fails_closed_before_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+):
+    """Would fail if malformed SCP syntax were reinterpreted as a local repository."""
+    paths = enrollment_paths(tmp_path)
+    git_calls: list[tuple[object, ...]] = []
+
+    def record_git(*arguments: object) -> str:
+        git_calls.append(arguments)
+        return ""
+
+    monkeypatch.setattr(profile_source, "_run_git", record_git)
+
+    with pytest.raises(ValueError) as raised:
+        resolve_profile_source(source, "test-development", "main", paths)
+
+    assert str(raised.value) == "profile source is invalid"
+    assert "synthetic-credential" not in str(raised.value)
+    assert redact_source(source) == "<redacted profile source>"
+    assert git_calls == []
+    assert cache_snapshot(paths) == {}
+
+
+def test_redact_source_is_total_for_arbitrary_unsafe_unicode_strings():
+    """Would fail if legacy status could raise or return unsafe Unicode source text."""
+    unsafe_sources = [
+        "\ud800",
+        "local\u0085synthetic-credential",
+        "local\u200esynthetic-credential",
+        "https：//profile-user:synthetic-credential@example.test/profile.git",
+        "https://example.test／synthetic-credential@example.test/profile.git",
+        "https://example.test:" + ("9" * 5000),
+    ]
+
+    assert [redact_source(source) for source in unsafe_sources] == [
+        "<redacted profile source>",
+        "<redacted profile source>",
+        "<redacted profile source>",
+        "<redacted profile source>",
+        "<redacted profile source>",
+        "<redacted profile source>",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source", "portable"),
+    [
+        ("https://example.test/profile.git", True),
+        ("https://[2001:db8::1]/profile.git", True),
+        ("ssh://git@example.test:22/profile.git", True),
+        ("ssh://example.test/profile.git", True),
+        ("ssh://git@[2001:db8::1]:22/profile.git", True),
+        ("git@example.test:profile?literal#literal.git", True),
+        ("example.test:profile.git", True),
+        ("./example.test:profile.git", False),
+        ("local?literal#literal", False),
+    ],
+)
+def test_supported_remote_and_local_grammars_remain_distinct(source: str, portable: bool):
+    """Would fail if strict rejection removed a supported URL, SCP, or local path."""
+    assert source_portability(source) is portable
+    assert redact_source(source) == source

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -80,6 +80,20 @@ def test_linear_completed_native_state_is_normalized_for_reconciliation():
     )
 
 
+def test_registry_passes_its_injected_environment_to_linear_provider(monkeypatch):
+    """Would fail if provider health silently fell back to ambient credentials."""
+    from ai_dlc.providers import Registry
+
+    monkeypatch.setenv("LINEAR_API_KEY", "ambient-value")
+
+    provider = Registry(
+        {"providers": {"linear": {"kind": "linear"}}},
+        environ={"LINEAR_API_KEY": "injected-value"},
+    ).get("linear")
+
+    assert provider.token == "injected-value"
+
+
 def test_linear_graphql_error():
     from ai_dlc.providers.linear import LinearProvider
 

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+def executable(path, body):
+    path.write_text("#!/bin/sh\n" + body)
+    path.chmod(0o755)
+    return path
+
+
 def test_headless_plan_omits_desktop_and_does_not_upgrade(tmp_path):
     from ai_dlc.provision import machine_plan
 
@@ -39,13 +45,311 @@ def test_doctor_checks_alias_provider_requirements(tmp_path, monkeypatch):
         'schema=4\n[roles]\ntracker="team-tracker"\n[providers.team-tracker]\nkind="linear"\ntoken_env="AI_DLC_TEST_MISSING_TOKEN"\n'
     )
     monkeypatch.delenv("AI_DLC_TEST_MISSING_TOKEN", raising=False)
-    monkeypatch.setattr(provision.shutil, "which", lambda name: None)
+    monkeypatch.setattr(provision.shutil, "which", lambda name, path=None: None)
     monkeypatch.setattr(agents, "render_agents", lambda root: {"changed": []})
     result = provision.doctor(tmp_path)
     assert not result["ready"]
     assert any("AI_DLC_TEST_MISSING_TOKEN" in s for s in result["signins"])
     assert any("team_id" in s for s in result["configuration"])
     assert any("closed" in s for s in result["configuration"])
+
+
+def test_doctor_uses_merged_bindings_and_shared_redacted_credential_readiness(
+    tmp_path, monkeypatch
+):
+    """Would fail if doctor bypassed bindings, changed provider kind, or leaked a value."""
+    from ai_dlc import agents, provision
+    from ai_dlc.providers import Registry
+
+    marker = "credential-value-that-must-not-escape-doctor"
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text("schema = 4\n")
+    home = tmp_path / "home"
+    home.mkdir()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    profile = tmp_path / "profile.toml"
+    profile.write_text(
+        """schema = 4
+profile_id = "portable-development"
+[roles]
+tracker = "linear-sandbox"
+[providers.linear-sandbox]
+kind = "linear"
+token_env = "LINEAR_SANDBOX_TOKEN"
+team_id = "portable-team"
+health_reference = "portable-health"
+[providers.linear-sandbox.statuses]
+in_progress = "started"
+closed = "completed"
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+[[agents.servers]]
+id = "notes"
+command = "notes-mcp"
+env = ["LINEAR_SANDBOX_TOKEN"]
+"""
+    )
+    machine = tmp_path / "machine.toml"
+    machine.write_text(
+        f"""schema = 4
+[paths]
+vault = "{vault}"
+[accounts]
+linear = "sandbox"
+[providers.linear-sandbox]
+account = "sandbox"
+[credentials.linear-sandbox]
+source = "environment"
+variable = "LINEAR_SANDBOX_TOKEN"
+"""
+    )
+    provider_configs: list[dict] = []
+
+    def fail_health(self, name, operation, payload):
+        del name, operation, payload
+        provider_configs.append(self.config)
+        raise RuntimeError(f"provider rejected {marker}")
+
+    monkeypatch.setattr(provision.shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(agents, "render_agents", lambda selected_root: {"changed": []})
+    monkeypatch.setattr(Registry, "invoke", fail_health)
+
+    result = provision.doctor(
+        root,
+        personal=profile,
+        machine=machine,
+        home=home,
+        environ={"LINEAR_SANDBOX_TOKEN": marker},
+    )
+
+    assert result["credentials"] == [
+        {
+            "id": "linear-sandbox",
+            "description": "Linear sandbox access",
+            "required_by": ["provider.linear-sandbox"],
+            "source": "environment",
+            "variable": "LINEAR_SANDBOX_TOKEN",
+            "configured": True,
+            "present": True,
+        }
+    ]
+    assert result["knowledge"] == "available"
+    assert result["user_agents"]["applied"] is False
+    assert result["user_agents"]["changed"]
+    assert result["provider_health"] == [
+        {"provider": "linear-sandbox", "ready": False, "reason": "provider health check failed"}
+    ]
+    assert provider_configs[0]["providers"]["linear-sandbox"]["kind"] == "linear"
+    assert provider_configs[0]["providers"]["linear-sandbox"]["account"] == "sandbox"
+    assert marker not in repr(result)
+    assert not list(home.iterdir())
+
+
+def test_doctor_redacts_logical_and_distinct_provider_compatibility_credentials(
+    tmp_path, monkeypatch
+):
+    """Would fail if any provider credential value survived a health failure."""
+    from ai_dlc import agents, provision
+    from ai_dlc.providers import Registry
+
+    logical_value = "logical-secret-value"
+    compatibility_value = "compatibility-secret-value"
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text("schema = 4\n")
+    profile = tmp_path / "profile.toml"
+    profile.write_text(
+        """schema = 4
+profile_id = "portable-development"
+[providers.linear-sandbox]
+kind = "linear"
+token_env = "LINEAR_COMPAT_TOKEN"
+health_reference = "portable-health"
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+"""
+    )
+    machine = tmp_path / "machine.toml"
+    machine.write_text(
+        """schema = 4
+[credentials.linear-sandbox]
+source = "environment"
+variable = "LINEAR_LOGICAL_TOKEN"
+"""
+    )
+
+    def fail_health(self, name, operation, payload):
+        del self, name, operation, payload
+        raise RuntimeError(f"failed with {logical_value} and {compatibility_value}")
+
+    monkeypatch.setattr(provision.shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(agents, "render_agents", lambda selected_root: {"changed": []})
+    monkeypatch.setattr(Registry, "invoke", fail_health)
+
+    result = provision.doctor(
+        root,
+        personal=profile,
+        machine=machine,
+        home=tmp_path / "home",
+        environ={
+            "LINEAR_LOGICAL_TOKEN": logical_value,
+            "LINEAR_COMPAT_TOKEN": compatibility_value,
+        },
+    )
+
+    assert logical_value not in repr(result)
+    assert compatibility_value not in repr(result)
+    assert result["provider_health"] == [
+        {"provider": "linear-sandbox", "ready": False, "reason": "provider health check failed"}
+    ]
+
+
+def test_doctor_reports_the_injected_default_linear_credential_as_absent_or_present(
+    tmp_path, monkeypatch
+):
+    """Would fail if the Linear default used ambient state or bypassed readiness."""
+    from types import SimpleNamespace
+
+    from ai_dlc import agents, provision
+
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text(
+        """schema = 4
+[roles]
+tracker = "linear-sandbox"
+[providers.linear-sandbox]
+kind = "linear"
+team_id = "portable-team"
+[providers.linear-sandbox.statuses]
+in_progress = "started"
+closed = "completed"
+"""
+    )
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    monkeypatch.setattr(provision.shutil, "which", lambda name, path=None: f"/bin/{name}")
+    monkeypatch.setattr(
+        provision.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="{}"),
+    )
+    monkeypatch.setattr(agents, "render_agents", lambda selected_root: {"changed": []})
+
+    absent = provision.doctor(root, environ={})
+    present = provision.doctor(root, environ={"LINEAR_API_KEY": "injected-only"})
+
+    assert absent["credentials"][0]["variable"] == "LINEAR_API_KEY"
+    assert absent["credentials"][0]["present"] is False
+    assert absent["signins"] == ["Set LINEAR_API_KEY using your credential store"]
+    assert absent["ready"] is False
+    assert present["credentials"][0]["present"] is True
+    assert present["signins"] == []
+    assert present["ready"] is True
+
+
+def test_doctor_provider_health_uses_the_same_explicit_environment_as_readiness(
+    tmp_path, monkeypatch
+):
+    """Would fail if executable health inherited a token that readiness cannot see."""
+    import hashlib
+
+    from ai_dlc import agents, provision
+
+    provider_marker = tmp_path / "provider-marker"
+    provider = executable(
+        tmp_path / "provider",
+        'if [ -n "$PROVIDER_MARKER" ]; then printf %s "$PROVIDER_TOKEN" > "$PROVIDER_MARKER"; fi\n'
+        '[ -n "$PROVIDER_TOKEN" ] || exit 42\n'
+        'printf \'{"id":"1","url":"https://example.test/1","state":"open"}\\n\'\n',
+    )
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text(
+        f'''schema = 4
+[providers.health]
+kind = "executable"
+command = "{provider}"
+sha256 = "{hashlib.sha256(provider.read_bytes()).hexdigest()}"
+token_env = "PROVIDER_TOKEN"
+health_reference = "1"
+'''
+    )
+    monkeypatch.setenv("PROVIDER_TOKEN", "ambient-token")
+    monkeypatch.setenv("PROVIDER_MARKER", str(provider_marker))
+    monkeypatch.setattr(provision.shutil, "which", lambda name, path=None: None)
+    monkeypatch.setattr(agents, "render_agents", lambda selected_root: {"changed": []})
+
+    isolated = provision.doctor(root, environ={})
+    assert isolated["credentials"][0]["present"] is False
+    assert isolated["provider_health"][0]["ready"] is False
+    assert not provider_marker.exists()
+
+    injected = provision.doctor(
+        root,
+        environ={
+            "PROVIDER_TOKEN": "injected-token",
+            "PROVIDER_MARKER": str(provider_marker),
+        },
+    )
+    assert injected["credentials"][0]["present"] is True
+    assert injected["provider_health"][0]["ready"] is True
+    assert provider_marker.read_text() == "injected-token"
+
+    provider_marker.unlink()
+    ambient = provision.doctor(root)
+    assert ambient["credentials"][0]["present"] is True
+    assert ambient["provider_health"][0]["ready"] is True
+    assert provider_marker.read_text() == "ambient-token"
+
+
+def test_doctor_command_discovery_and_execution_respect_explicit_path(tmp_path, monkeypatch):
+    """Would fail if doctor discovered or ran ambient tools for an explicit environment."""
+    from ai_dlc import agents, provision
+
+    ambient_bin = tmp_path / "ambient-bin"
+    ambient_bin.mkdir()
+    injected_bin = tmp_path / "injected-bin"
+    injected_bin.mkdir()
+    ambient_trace = tmp_path / "ambient-trace"
+    injected_trace = tmp_path / "injected-trace"
+    for binary_dir in [ambient_bin, injected_bin]:
+        executable(binary_dir / "git", "exit 0\n")
+        executable(
+            binary_dir / "mise",
+            'printf %s "$TOOL_ORIGIN" >> "$TRACE_FILE"\n'
+            'if [ "$1" = "ls" ]; then printf \'{}\\n\'; fi\n',
+        )
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "ai-dlc.toml").write_text("schema = 4\n")
+    monkeypatch.setenv("PATH", str(ambient_bin))
+    monkeypatch.setenv("TOOL_ORIGIN", "ambient")
+    monkeypatch.setenv("TRACE_FILE", str(ambient_trace))
+    monkeypatch.setattr(agents, "render_agents", lambda selected_root: {"changed": []})
+
+    isolated = provision.doctor(root, environ={})
+    assert isolated["missing"] == ["git", "mise"]
+    assert not ambient_trace.exists()
+
+    injected = provision.doctor(
+        root,
+        environ={
+            "PATH": str(injected_bin),
+            "TOOL_ORIGIN": "injected",
+            "TRACE_FILE": str(injected_trace),
+        },
+    )
+    assert injected["missing"] == []
+    assert injected_trace.read_text() == "injected"
+    assert not ambient_trace.exists()
+
+    ambient = provision.doctor(root)
+    assert ambient["missing"] == []
+    assert ambient_trace.read_text() == "ambient"
 
 
 def test_machine_apply_activates_runtimes_and_personal_agents(tmp_path, monkeypatch):
@@ -74,6 +378,17 @@ command="notes-mcp"
 env=["NOTES_TOKEN"]
 """
     )
+    machine = tmp_path / "machine.toml"
+    machine.write_text(
+        """schema = 4
+[paths]
+vault = "/machine/vault"
+[accounts]
+notes = "personal"
+"""
+    )
+    marker = "credential-value-that-must-not-be-rendered"
+    monkeypatch.setenv("NOTES_TOKEN", marker)
     monkeypatch.setenv("PATH", f"{binaries}:/usr/bin:/bin")
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     monkeypatch.setenv("AI_DLC_BOOTSTRAP_HOME", str(bootstrap))
@@ -81,7 +396,7 @@ env=["NOTES_TOKEN"]
     monkeypatch.setattr("ai_dlc.provision.platform.system", lambda: "Darwin")
     monkeypatch.setattr("ai_dlc.provision.platform.machine", lambda: "arm64")
 
-    result = machine_apply(profile, home=home)
+    result = machine_apply(profile, home=home, machine=machine)
 
     assert result["ready"] is True
     assert result["workstation"]["ready"] is True
@@ -95,6 +410,8 @@ env=["NOTES_TOKEN"]
         "command": "notes-mcp",
         "env": {"NOTES_TOKEN": "${NOTES_TOKEN}"},
     }
+    assert marker not in repr(result)
+    assert all(marker not in path.read_text() for path in home.rglob("*") if path.is_file())
 
 
 def test_machine_plan_previews_personal_agents_without_writing(tmp_path):
@@ -108,6 +425,69 @@ def test_machine_plan_previews_personal_agents_without_writing(tmp_path):
     assert result["agent_configuration"]["clean"] is False
     assert result["agent_configuration"]["applied"] is False
     assert not list(home.iterdir())
+
+
+def test_machine_plan_merges_machine_readiness_without_exposing_environment_values(
+    tmp_path, monkeypatch
+):
+    """Would fail if machine bindings were ignored or a credential value entered a plan."""
+    from ai_dlc.provision import machine_plan
+
+    marker = "credential-value-that-must-not-enter-the-plan"
+    profile = tmp_path / "profile.toml"
+    profile.write_text(
+        """schema = 4
+profile_id = "portable-development"
+[preferences]
+headless = false
+[providers.linear-sandbox]
+kind = "linear"
+token_env = "LINEAR_SANDBOX_TOKEN"
+[credentials.linear-sandbox]
+description = "Linear sandbox access"
+required_by = ["provider.linear-sandbox"]
+"""
+    )
+    machine = tmp_path / "machine.toml"
+    machine.write_text(
+        """schema = 4
+[preferences]
+headless = true
+[paths]
+vault = "/machine/vault"
+[accounts]
+linear = "sandbox"
+[providers.linear-sandbox]
+account = "sandbox"
+[credentials.linear-sandbox]
+source = "environment"
+variable = "LINEAR_SANDBOX_TOKEN"
+"""
+    )
+    monkeypatch.delenv("LINEAR_SANDBOX_TOKEN", raising=False)
+
+    result = machine_plan(
+        profile,
+        machine=machine,
+        system="Darwin",
+        architecture="arm64",
+        home=tmp_path / "home",
+        environ={"LINEAR_SANDBOX_TOKEN": marker},
+    )
+
+    assert result["headless"] is True
+    assert result["credentials"] == [
+        {
+            "id": "linear-sandbox",
+            "description": "Linear sandbox access",
+            "required_by": ["provider.linear-sandbox"],
+            "source": "environment",
+            "variable": "LINEAR_SANDBOX_TOKEN",
+            "configured": True,
+            "present": True,
+        }
+    ]
+    assert marker not in repr(result)
 
 
 def test_machine_apply_scopes_default_workstation_state_to_explicit_home(tmp_path, monkeypatch):
@@ -133,3 +513,61 @@ def test_machine_apply_scopes_default_workstation_state_to_explicit_home(tmp_pat
     machine_apply(profile, home=home)
 
     assert (home / ".local/share/ai-dlc/workstation").is_dir()
+
+
+def test_machine_apply_command_discovery_and_execution_respect_explicit_path(tmp_path, monkeypatch):
+    """Would fail if apply selected or ran ambient mise for an explicit environment."""
+    from ai_dlc.provision import machine_apply
+
+    ambient_bin = tmp_path / "ambient-bin"
+    ambient_bin.mkdir()
+    injected_bin = tmp_path / "injected-bin"
+    injected_bin.mkdir()
+    ambient_trace = tmp_path / "ambient-trace"
+    injected_trace = tmp_path / "injected-trace"
+    for binary_dir in [ambient_bin, injected_bin]:
+        for name in ["brew", "mise"]:
+            executable(
+                binary_dir / name,
+                'printf "%s:%s\\n" "$TOOL_ORIGIN" "$*" >> "$TRACE_FILE"\n',
+            )
+    profile = tmp_path / "profile.toml"
+    profile.write_text('schema = 4\n[modules]\ninclude = ["python"]\n')
+    monkeypatch.setenv("PATH", str(ambient_bin))
+    monkeypatch.setenv("TOOL_ORIGIN", "ambient")
+    monkeypatch.setenv("TRACE_FILE", str(ambient_trace))
+    monkeypatch.setattr("ai_dlc.provision.platform.system", lambda: "Darwin")
+    monkeypatch.setattr("ai_dlc.provision.platform.machine", lambda: "arm64")
+
+    with pytest.raises(RuntimeError, match="mise is required"):
+        machine_apply(profile, home=tmp_path / "empty-home", environ={})
+    assert not ambient_trace.exists()
+
+    injected = machine_apply(
+        profile,
+        home=tmp_path / "injected-home",
+        environ={
+            "PATH": str(injected_bin),
+            "TOOL_ORIGIN": "injected",
+            "TRACE_FILE": str(injected_trace),
+        },
+    )
+    assert injected["ready"] is True
+    assert injected_trace.read_text().splitlines() == [
+        "injected:bundle --no-upgrade --file "
+        + str(tmp_path / "injected-home/.local/share/ai-dlc/workstation/Brewfile"),
+        "injected:trust "
+        + str(tmp_path / "injected-home/.local/share/ai-dlc/workstation/.mise.toml"),
+        "injected:install",
+    ]
+    assert not ambient_trace.exists()
+
+    ambient = machine_apply(profile, home=tmp_path / "ambient-home")
+    assert ambient["ready"] is True
+    assert ambient_trace.read_text().splitlines() == [
+        "ambient:bundle --no-upgrade --file "
+        + str(tmp_path / "ambient-home/.local/share/ai-dlc/workstation/Brewfile"),
+        "ambient:trust "
+        + str(tmp_path / "ambient-home/.local/share/ai-dlc/workstation/.mise.toml"),
+        "ambient:install",
+    ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,8 +1,216 @@
+import asyncio
+import os
+import re
 import subprocess
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+from urllib.parse import unquote
 
 import pytest
 
+from ai_dlc.config import resolve_files
+from ai_dlc.credentials import credential_status
+from ai_dlc.files import assets
 from ai_dlc.templates import adopt, sync
+
+_PROHIBITED_PUBLIC_TOKENS = {
+    "personal",
+    "account",
+    "organization",
+    "org",
+    "owner",
+    "email",
+    "workspace",
+    "team",
+    "vault",
+    "repository",
+    "remote",
+    "path",
+    "password",
+    "secret",
+    "api",
+    "key",
+    "token",
+    "access",
+}
+_REFERENCE_KEYS = {"token_env", "variable"}
+_ENVIRONMENT_NAME = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_POSIX_PATH = re.compile(r"(?<![\w.~-])/(?![/\s])[^\s`\"'<>()\[\]{}]+")
+_WINDOWS_DRIVE_PATH = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s`\"'<>()\[\]{}]+")
+_UNC_PATH = re.compile(r"(?<!\\)\\\\[^\\/\s]+[\\/][^\s`\"'<>()\[\]{}]+")
+_HOME_PATH = re.compile(r"(?<![\w])~(?:[A-Za-z0-9._-]+)?[\\/][^\s`\"'<>()\[\]{}]+")
+_REMOTE_URL = re.compile(r"(?i)\b(?:https?|ssh|git|file)://")
+_SCP_REMOTE = re.compile(
+    r"(?i)(?<![\w@.-])(?:[\w.+-]+@)?[A-Za-z0-9][\w.-]*:"
+    r"(?:~?[\\/])?[^\s:]+[\\/][^\s]+"
+)
+_EMAIL_ADDRESS = re.compile(r"[\w.+-]+@[\w.-]+")
+_STRIPE_LIKE_PREFIX = "sk" + "_live_"
+_CREDENTIAL_SIGNATURE = re.compile(
+    r"(?<![A-Za-z0-9])(?:ghp_[A-Za-z0-9]{20,}|AKIA[A-Z0-9]{12,}|"
+    + re.escape(_STRIPE_LIKE_PREFIX)
+    + r"[A-Za-z0-9]{8,})(?![A-Za-z0-9])"
+)
+_PLACEHOLDER_SECRET = re.compile(
+    r"(?i)(?<![A-Za-z0-9])(?:placeholder|representative)[-_ ]secret(?![A-Za-z0-9])"
+)
+_SECRET_VALUE_TOKENS = {"password", "secret", "token", "key"}
+_SURROUNDING_PUNCTUATION = " \t\r\n`*()[]{}<>\"',;!?"
+_TOML_KEY_PART = r'(?:[A-Za-z_][A-Za-z0-9_-]*|"[^"\r\n]+"|\'[^\'\r\n]+\')'
+_COMMENTED_ASSIGNMENT = re.compile(
+    rf"^\s*(?P<lhs>{_TOML_KEY_PART}(?:\s*\.\s*{_TOML_KEY_PART})*)\s*="
+)
+_TOML_KEY_COMPONENT = re.compile(_TOML_KEY_PART)
+
+_HANDBOOK_TRANSLATION = str.maketrans(
+    {
+        "‘": "'",
+        "’": "'",
+        "ʼ": "'",
+        "‐": "-",
+        "‑": "-",
+        "‒": "-",
+        "–": "-",
+        "—": "-",
+        "―": "-",
+        "−": "-",
+    }
+)
+_HANDBOOK_TARGET = re.compile(
+    r"(?:\.env(?:\.(?:\*|[a-z0-9_-]+))?(?:\s+files?)?|credential\s+values?)"
+)
+_HANDBOOK_ACTION_BODY = (
+    r"(?:git\s+(?:add|commit(?:ting)?)|commit(?:ting)?|stag(?:e|ing)|"
+    r"track(?:ing)?|check[- ]in|version[- ]control)"
+)
+_HANDBOOK_ACTION = re.compile(rf"\b{_HANDBOOK_ACTION_BODY}\b")
+_HANDBOOK_SENTENCE_BREAK = re.compile(r"[!?]+|\.(?=\s|$)")
+_HANDBOOK_CLAUSE_BREAK = re.compile(
+    r"(?:[;]+|,?\s+\b(?:but|however|yet|whereas|although|though|instead)\b\s*,?\s*)"
+)
+_DIRECT_ACTION_NEGATION = re.compile(
+    r"\b(?:never(?:\s*,?\s*ever)?|do\s+not(?:\s+ever)?|don't(?:\s+ever)?|"
+    r"must\s+not(?:\s+ever)?|avoid(?:\s+ever)?)\s*,?\s*$"
+)
+_NEGATION_REVERSAL = re.compile(r"\b(?:unless|except)\b")
+_PERMISSION_REVERSAL = re.compile(
+    rf"\b(?:you\s+)?(?:may|can)\b[^!?;]*?\b(?:do\s+so|{_HANDBOOK_ACTION_BODY})\b"
+)
+
+
+def _key_tokens(key):
+    separated = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", key)
+    separated = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", separated)
+    return set(re.split(r"[-_.\s]+", separated.lower())) - {""}
+
+
+def _assert_public_identifier(identifier, location=""):
+    if identifier in _REFERENCE_KEYS:
+        return
+    assert not (_key_tokens(identifier) & _PROHIBITED_PUBLIC_TOKENS), location
+
+
+def _assert_public_value(value, location=""):
+    content = unquote(value).strip(_SURROUNDING_PUNCTUATION)
+    assert not _CREDENTIAL_SIGNATURE.search(content), location
+    assert not _PLACEHOLDER_SECRET.search(content), location
+    if _ENVIRONMENT_NAME.fullmatch(content):
+        return
+    assert not _POSIX_PATH.search(content), location
+    assert not _WINDOWS_DRIVE_PATH.search(content), location
+    assert not _UNC_PATH.search(content), location
+    assert not _HOME_PATH.search(content), location
+    assert not _REMOTE_URL.search(content), location
+    assert not _SCP_REMOTE.search(content), location
+    assert not _EMAIL_ADDRESS.search(content), location
+    if re.fullmatch(r"[A-Za-z0-9_-]+", content):
+        assert not (_key_tokens(content) & _SECRET_VALUE_TOKENS), location
+
+
+def _assert_public_example(value, location=""):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            _assert_public_identifier(key, location)
+            if key in _REFERENCE_KEYS:
+                assert isinstance(child, str) and _ENVIRONMENT_NAME.fullmatch(child), location
+            _assert_public_example(child, f"{location}.{key}".strip("."))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _assert_public_example(child, f"{location}[{index}]")
+    elif isinstance(value, str):
+        _assert_public_value(value, location)
+
+
+def _toml_comment_payloads(raw):
+    delimiter = None
+    escaped = False
+    index = 0
+    while index < len(raw):
+        if delimiter:
+            if len(delimiter) == 3:
+                if raw.startswith(delimiter, index):
+                    delimiter = None
+                    index += 3
+                    continue
+            elif delimiter == '"':
+                if escaped:
+                    escaped = False
+                elif raw[index] == "\\":
+                    escaped = True
+                elif raw[index] == delimiter:
+                    delimiter = None
+            elif raw[index] == delimiter:
+                delimiter = None
+        elif raw.startswith(('"""', "'''"), index):
+            delimiter = raw[index : index + 3]
+            index += 3
+            continue
+        elif raw[index] in {'"', "'"}:
+            delimiter = raw[index]
+        elif raw[index] == "#":
+            end = raw.find("\n", index)
+            if end == -1:
+                end = len(raw)
+            yield raw[index + 1 : end]
+            index = end
+            continue
+        index += 1
+
+
+def _assert_public_raw_content(raw):
+    _assert_public_example(tomllib.loads(raw))
+    for payload in _toml_comment_payloads(raw):
+        _assert_public_value(payload, "comment")
+        assignment = _COMMENTED_ASSIGNMENT.match(payload)
+        if not assignment:
+            continue
+        for component in _TOML_KEY_COMPONENT.finditer(assignment.group("lhs")):
+            identifier = component.group(0).strip("\"'")
+            _assert_public_identifier(identifier, identifier)
+
+
+def _assert_handbook_safety(pages):
+    for page in pages.values():
+        normalized = page.translate(_HANDBOOK_TRANSLATION).lower()
+        normalized = re.sub(r"[`*_~]+", "", normalized)
+        normalized = " ".join(normalized.split())
+        for sentence in _HANDBOOK_SENTENCE_BREAK.split(normalized):
+            protected_rule_seen = False
+            cursor = 0
+            for clause in _HANDBOOK_CLAUSE_BREAK.split(sentence):
+                clause_start = sentence.find(clause, cursor)
+                cursor = clause_start + len(clause)
+                if protected_rule_seen and _PERMISSION_REVERSAL.search(clause):
+                    raise AssertionError("protected handbook rule is reversed")
+                if not _HANDBOOK_TARGET.search(clause):
+                    continue
+                for action in _HANDBOOK_ACTION.finditer(clause):
+                    assert _DIRECT_ACTION_NEGATION.search(clause[: action.start()])
+                    protected_rule_seen = True
+                    action_end = clause_start + action.end()
+                    assert not _NEGATION_REVERSAL.search(sentence[action_end:])
 
 
 def git(root, *args):
@@ -135,6 +343,479 @@ def test_project_template_includes_workflow_handbook(tmp_path, capabilities):
         "## Verification strategy",
         "## Delivery and recovery",
     } <= design_headings
+
+
+def test_portable_profile_examples_and_rendered_handbook_are_safe(tmp_path):
+    """Catch a missing packaged enrollment example or an unsafe generated handbook."""
+    profile_path = assets("profiles") / "example/ai-dlc-profile.toml"
+    machine_path = assets("profiles") / "machines/example.toml"
+
+    assert profile_path.is_file()
+    profile = tomllib.loads(profile_path.read_text())
+    resolved_profile = resolve_files(personal=profile_path).values
+    assert resolved_profile["profile_id"] == "example-development"
+    assert resolved_profile["modules"]["include"] == ["core", "python"]
+    assert resolved_profile["agents"]["servers"] == []
+    assert profile["roles"] == {
+        "specs": "openspec",
+        "tracker": "linear",
+        "knowledge": "obsidian",
+        "scm": "github",
+        "deploy": "none",
+        "agent-client": ["claude-code", "codex"],
+    }
+    assert profile["credentials"] == {
+        "linear-sandbox": {
+            "description": "Credential for a sandbox tracker integration",
+            "required_by": ["provider.linear"],
+        }
+    }
+
+    machine = tomllib.loads(machine_path.read_text())
+    resolved = resolve_files(personal=profile_path, machine=machine_path).values
+    assert machine["credentials"]["linear-sandbox"] == {
+        "source": "environment",
+        "variable": "LINEAR_SANDBOX_TOKEN",
+    }
+    assert credential_status(resolved, environ={}) == [
+        {
+            "id": "linear-sandbox",
+            "description": "Credential for a sandbox tracker integration",
+            "required_by": ["provider.linear"],
+            "source": "environment",
+            "variable": "LINEAR_SANDBOX_TOKEN",
+            "configured": True,
+            "present": False,
+        }
+    ]
+
+    _assert_public_example(profile)
+    _assert_public_example(machine)
+    for raw in [profile_path.read_text(), machine_path.read_text()]:
+        _assert_public_raw_content(raw)
+
+    root = tmp_path / "generated-project"
+    assert adopt(root, apply=True)["status"] == "applied"
+    pages = {path.relative_to(root): path.read_text() for path in root.rglob("*.md")}
+    handbook = "\n".join(pages.values()).lower()
+    for topic in [
+        "portable profile",
+        "machine enrollment",
+        "credential",
+        "local cli",
+        "hosted",
+        "design",
+        "implementation",
+    ]:
+        assert topic in handbook
+    assert "ai-dlc machine enroll source --profile-id" in handbook
+    assert "ai-dlc machine sync --apply" in handbook
+    from ai_dlc.mcp_server import make_server
+
+    mcp_tools = {tool.name for tool in asyncio.run(make_server(root).list_tools())}
+    tool_map = pages[Path("docs/workflows/tool-map.md")].lower()
+    documented_mcp_tools = set(re.findall(r"`((?:work|knowledge)_[a-z_]+|doctor)`", tool_map))
+    assert documented_mcp_tools == mcp_tools
+    assert not {name for name in mcp_tools if name.startswith("machine_")}
+    assert not re.findall(r"`machine_[a-z_]+`", tool_map)
+    _assert_handbook_safety(pages)
+    git(root, "init")
+    for relative in [".env", ".env.local", ".ai-dlc/local/review.json"]:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ignored")
+        assert (
+            subprocess.run(
+                ["git", "-C", str(root), "check-ignore", "-q", relative], check=False
+            ).returncode
+            == 0
+        )
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "workspace_id",
+        "workspace-id",
+        "workspaceId",
+        "owner_email",
+        "owner-email",
+        "ownerEmail",
+        "api_token",
+        "api-token",
+        "apiToken",
+        "APIToken",
+        "account",
+        "organization",
+        "org",
+        "team",
+        "vault",
+        "repository",
+        "remote",
+        "local_path",
+        "local-path",
+        "localPath",
+        "password",
+        "client_secret",
+        "access_key",
+    ],
+)
+def test_public_example_helper_rejects_sensitive_identifiers(identifier):
+    with pytest.raises(AssertionError):
+        _assert_public_example({"outer": {"nested": {identifier: "neutral"}}})
+
+
+def test_public_example_helper_rejects_sensitive_nested_parsed_toml_keys():
+    parsed = tomllib.loads('[outer.nested]\n"APIToken" = "neutral"\n')
+
+    with pytest.raises(AssertionError):
+        _assert_public_example(parsed)
+
+
+def test_public_example_helper_allows_schema_and_environment_bindings():
+    _assert_public_example(
+        {
+            "schema": 4,
+            "profile_id": "example-development",
+            "roles": {"specs": "openspec"},
+            "paths": {},
+            "providers": {"linear": {"token_env": "LINEAR_SANDBOX_TOKEN"}},
+            "credentials": {
+                "linear-sandbox": {
+                    "description": "Ordinary path and key prose",
+                    "required_by": ["provider.linear"],
+                    "source": "environment",
+                    "variable": "LINEAR_SANDBOX_TOKEN",
+                }
+            },
+        }
+    )
+
+
+_SENSITIVE_PARSED_VALUES = [
+    "person@example.test",
+    "/Users/example/profile",
+    "~/profiles/example",
+    r"C:\Users\example\profile",
+    r"\\server\share\profile",
+    "http://example.test/group/profile.git",
+    "https://example.test/group/profile.git",
+    "ssh://git@example.test/group/profile.git",
+    "git://example.test/group/profile.git",
+    "git@example.test:group/profile.git",
+    "ghp_000000000000000000000000000000000000",
+    "AKIA0000000000000000",
+    _STRIPE_LIKE_PREFIX + "000000000000000000000000",
+    "representative-secret",
+    "Review (/Users/example/profile), then continue.",
+    r"Review [C:\Users\example\profile], then continue.",
+    r"Review (\\server\share\profile), then continue.",
+    "Review ~example/profiles/example, then continue.",
+    "http%3A%2F%2Fexample.test/group/profile.git",
+    "https%3a%2f%2fexample.test/group/profile.git",
+    "ssh%3A%2F%2Fexample.test/group/profile.git",
+    "git%3A%2F%2Fexample.test/group/profile.git",
+    "example.test:group/profile.git",
+    "The reviewer mutation contains (placeholder-secret).",
+    "First line is neutral.\nA later line names /Users/example/profile.",
+]
+
+
+@pytest.mark.parametrize("value", _SENSITIVE_PARSED_VALUES)
+def test_public_example_helper_rejects_sensitive_value_shapes(value):
+    with pytest.raises(AssertionError):
+        _assert_public_example({"description": value})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Ordinary prose can discuss a path or key without containing either value.",
+        "provider.linear",
+        "example-development",
+        "LINEAR_SANDBOX_TOKEN",
+    ],
+)
+def test_public_example_helper_allows_benign_content_values(value):
+    _assert_public_example({"description": value})
+
+
+def test_public_example_helper_scans_decoded_multiline_toml_values():
+    parsed = tomllib.loads(
+        'description = """First line is neutral.\nA later line names /Users/example/profile.\n"""'
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_public_example(parsed)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '# workspace_id = "neutral"',
+        '# owner-email = "neutral"',
+        '# ownerEmail = "neutral"',
+        '# apiToken = "neutral"',
+        '# "ownerEmail" = "neutral"',
+        '# owner.email = "neutral"',
+        '# credentials."APIToken" = "neutral"',
+    ],
+)
+def test_public_raw_helper_rejects_commented_sensitive_identifiers(raw):
+    with pytest.raises(AssertionError):
+        _assert_public_raw_content(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        'description = "person@example.test"',
+        'description = "/Users/example/profile"',
+        'description = "~/profiles/example"',
+        r'description = "C:\\Users\\example\\profile"',
+        r'description = "\\\\server\\share\\profile"',
+        'description = "http://example.test/group/profile.git"',
+        'description = "https://example.test/group/profile.git"',
+        'description = "ssh://git@example.test/group/profile.git"',
+        'description = "git://example.test/group/profile.git"',
+        'description = "git@example.test:group/profile.git"',
+        'description = "ghp_000000000000000000000000000000000000"',
+        'description = "AKIA0000000000000000"',
+        f'description = "{_STRIPE_LIKE_PREFIX}000000000000000000000000"',
+        'description = "representative-secret"',
+        'description = "Review (/Users/example/profile), then continue."',
+        'description = "Review ~example/profiles/example, then continue."',
+        'description = "https%3A%2F%2Fexample.test/group/profile.git"',
+        'description = "example.test:group/profile.git"',
+        'description = "The reviewer mutation contains (placeholder-secret)."',
+        'description = """First line is neutral.\nA later line names /Users/example/profile.\n"""',
+    ],
+)
+def test_public_raw_helper_rejects_sensitive_value_shapes(raw):
+    tomllib.loads(raw)
+    with pytest.raises(AssertionError):
+        _assert_public_raw_content(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "# Explain which path or key label a reader should choose.",
+        'description = "The path and key words are ordinary prose."',
+        '# Path and key are prose, not fields.\ndescription = "Neutral guidance"',
+        'variable = "LINEAR_SANDBOX_TOKEN"',
+        'token_env = "LINEAR_SANDBOX_TOKEN"',
+        'description = "provider.linear"',
+        'profile_id = "example-development"',
+    ],
+)
+def test_public_raw_helper_allows_benign_prose_and_environment_names(raw):
+    tomllib.loads(raw)
+    _assert_public_raw_content(raw)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    _SENSITIVE_PARSED_VALUES,
+)
+def test_public_raw_helper_rejects_sensitive_comment_payloads(payload):
+    comments = "\n".join(f"# {line}" for line in payload.splitlines())
+
+    with pytest.raises(AssertionError):
+        _assert_public_raw_content(f'{comments}\ndescription = "Neutral guidance"\n')
+
+
+@pytest.mark.parametrize(
+    "comment",
+    [
+        "# Explain which path or key label a reader should choose.",
+        "# provider.linear is a provider identifier.",
+        "# example-development is a profile identifier.",
+        "# LINEAR_SANDBOX_TOKEN is an environment-variable name.",
+    ],
+)
+def test_public_raw_helper_allows_benign_comment_payloads(comment):
+    _assert_public_raw_content(f'{comment}\ndescription = "Neutral guidance"\n')
+
+
+_HANDBOOK_ACTIONS = [
+    "git add",
+    "git commit",
+    "commit",
+    "stage",
+    "track",
+    "check in",
+    "check-in",
+    "version control",
+    "version-control",
+]
+
+
+@pytest.mark.parametrize("action", _HANDBOOK_ACTIONS)
+@pytest.mark.parametrize(
+    "target", [".env", ".env.local", ".env.* files", "credential value", "credential values"]
+)
+def test_handbook_helper_rejects_unguarded_protected_actions(action, target):
+    with pytest.raises(AssertionError):
+        _assert_handbook_safety({"guide": f"Before release, {action}\n{target}."})
+
+
+@pytest.mark.parametrize(
+    "guide",
+    [
+        "Do not panic but commit .env.",
+        "Don't hesitate to commit credential values.",
+        "Never commit docs but track .env.",
+        "Run git add\n.env before release.",
+        "Use check-in\ncredential values.",
+        "Do not expose secrets, but track .env.",
+        "Do not commit .env unless a developer needs it.",
+        "Never commit .env except during setup.",
+        "Never commit .env, but you may do so during setup.",
+        "Never commit .env, but you can do so during setup.",
+        "Never commit .env, but you may safely do so after review.",
+        "Never commit .env, but you may commit it during setup.",
+        "Run git **add** .env before release.",
+        "Run `git add` `.env` before release.",
+        "Start committing .env during setup.",
+        "Begin staging credential values during setup.",
+        "Keep tracking .env during setup.",
+        "Use check‑in for .env files.",
+        "Use version–control for .env files.",
+    ],
+)
+def test_handbook_helper_rejects_negation_and_contrast_bypasses(guide):
+    with pytest.raises(AssertionError):
+        _assert_handbook_safety({"guide": guide})
+
+
+@pytest.mark.parametrize("action", _HANDBOOK_ACTIONS)
+@pytest.mark.parametrize(
+    "negation",
+    [
+        "Never",
+        "Do not",
+        "Don't",
+        "Must not",
+        "Avoid",
+        "Never ever",
+        "Do not ever",
+        "Don't ever",
+        "Must not ever",
+        "Avoid ever",
+    ],
+)
+def test_handbook_helper_allows_direct_action_negation(action, negation):
+    _assert_handbook_safety({"guide": f"{negation} {action}\ncredential values or .env files."})
+
+
+@pytest.mark.parametrize(
+    "guide",
+    [
+        "Don’t commit .env.",
+        "Do not **commit** .env.",
+        "Do not `commit` `.env`.",
+        "Never, ever commit .env.",
+        "Never commit .env, but store credentials in a keychain.",
+    ],
+)
+def test_handbook_helper_allows_normalized_direct_negation(guide):
+    _assert_handbook_safety({"guide": guide})
+
+
+def test_portable_examples_are_the_only_profiles_in_built_distributions(tmp_path):
+    """Catch private assets in either release artifact while validating public profiles."""
+    project = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [
+            "uv",
+            "build",
+            "--out-dir",
+            str(tmp_path),
+        ],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "UV_OFFLINE": "1"},
+    )
+    wheel = next(tmp_path.glob("ai_dlc-*.whl"))
+    source_distribution = next(tmp_path.glob("ai_dlc-*.tar.gz"))
+    wheel_profiles = {
+        "ai_dlc/assets/profiles/base.toml",
+        "ai_dlc/assets/profiles/example/ai-dlc-profile.toml",
+        "ai_dlc/assets/profiles/machines/example.toml",
+    }
+    with zipfile.ZipFile(wheel) as archive:
+        members = archive.namelist()
+        actual_wheel_profiles = {
+            name for name in archive.namelist() if name.startswith("ai_dlc/assets/profiles/")
+        }
+        assert actual_wheel_profiles == wheel_profiles
+        profile_bytes = archive.read("ai_dlc/assets/profiles/example/ai-dlc-profile.toml")
+        machine_bytes = archive.read("ai_dlc/assets/profiles/machines/example.toml")
+
+    with tarfile.open(source_distribution) as archive:
+        raw_source_members = [member.name for member in archive.getmembers()]
+        source_root = raw_source_members[0].split("/", 1)[0]
+        members.extend(name.removeprefix(f"{source_root}/") for name in raw_source_members)
+        actual_source_profiles = {
+            name.removeprefix(f"{source_root}/")
+            for name in raw_source_members
+            if name.removeprefix(f"{source_root}/").startswith("profiles/")
+            and name.endswith(".toml")
+        }
+        assert actual_source_profiles == {
+            "profiles/base.toml",
+            "profiles/example/ai-dlc-profile.toml",
+            "profiles/machines/example.toml",
+        }
+
+    def is_forbidden_member(name: str) -> bool:
+        parts = Path(name).parts
+        return bool(
+            ".git" in parts
+            or Path(name).name in {"enrollment.toml", "sean.toml"}
+            or Path(name).name.startswith(".env")
+            or any(parts[index : index + 2] == (".ai-dlc", "local") for index in range(len(parts)))
+        )
+
+    assert not [name for name in members if is_forbidden_member(name)]
+
+    local_user = b"sean" + b"koval"
+    forbidden_content = [b"/Users/" + local_user, local_user, str(project).encode()]
+
+    def contains_forbidden_content(content: bytes) -> bool:
+        return any(marker in content for marker in forbidden_content)
+
+    with zipfile.ZipFile(wheel) as archive:
+        assert not [
+            name
+            for name in archive.namelist()
+            if not name.endswith("/") and contains_forbidden_content(archive.read(name))
+        ]
+    with tarfile.open(source_distribution) as archive:
+        assert not [
+            member.name
+            for member in archive.getmembers()
+            if member.isfile()
+            and (content := archive.extractfile(member)) is not None
+            and contains_forbidden_content(content.read())
+        ]
+
+    profile_raw = profile_bytes.decode()
+    machine_raw = machine_bytes.decode()
+    _assert_public_example(tomllib.loads(profile_raw))
+    _assert_public_example(tomllib.loads(machine_raw))
+    _assert_public_raw_content(profile_raw)
+    _assert_public_raw_content(machine_raw)
+    profile_path = tmp_path / "wheel-profile.toml"
+    machine_path = tmp_path / "wheel-machine.toml"
+    profile_path.write_bytes(profile_bytes)
+    machine_path.write_bytes(machine_bytes)
+    resolved = resolve_files(personal=profile_path, machine=machine_path).values
+    assert resolved["profile_id"] == "example-development"
+    assert credential_status(resolved, environ={})[0]["variable"] == "LINEAR_SANDBOX_TOKEN"
 
 
 def test_initialized_python_check_does_not_dirty_repository(tmp_path):

--- a/tests/test_user_agents.py
+++ b/tests/test_user_agents.py
@@ -21,17 +21,24 @@ def test_preview_then_apply_is_home_scoped_and_idempotent(tmp_path, monkeypatch)
     config = personal(
         {"id": "notes", "command": "notes-mcp", "args": ["serve"], "env": ["ACCESS_TOKEN"]}
     )
-    result = render_user_agents(config, home)
-    assert result["changed"] and result["applied"] is False
+    preview = render_user_agents(config, home)
+    assert preview["changed"] and preview["applied"] is False
     assert not list(home.iterdir())
-    assert render_user_agents(config, home, apply=True)["applied"] is True
+    applied = render_user_agents(config, home, apply=True)
+    assert applied["applied"] is True
     assert not list(project.iterdir())
     claude = json.loads((home / ".claude.json").read_text())
     codex = tomllib.loads((home / ".codex/config.toml").read_text())
     assert claude["mcpServers"]["notes"]["env"] == {"ACCESS_TOKEN": "${ACCESS_TOKEN}"}
     assert codex["mcp_servers"]["notes"]["env_vars"] == ["ACCESS_TOKEN"]
-    assert all("must-never-be-written" not in p.read_text() for p in home.rglob("*") if p.is_file())
-    assert render_user_agents(config, home)["clean"] is True
+    assert all(
+        b"must-never-be-written" not in path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    )
+    clean = render_user_agents(config, home)
+    assert clean["clean"] is True
+    assert "must-never-be-written" not in repr((preview, applied, clean))
 
 
 def test_empty_personal_config_does_not_invent_servers_or_write(tmp_path):


### PR DESCRIPTION
## Motivation

AI-DLC needs a provider-neutral way to carry the same development profile across machines while keeping machine bindings, credentials, and mutable state local.

## What changed

- Add schema-v5 portable profile identity, scoped credentials, and environment-reference-only bindings.
- Add atomic machine enrollment state and an immutable exact-ref Git cache with offline verification.
- Add preview, enroll, migrate, status, plan, apply, sync, and doctor lifecycle behavior with lock-last activation.
- Preserve scoped merge precedence across portable personal, project, and machine layers, including partial CLI overrides.
- Add real two-machine integration coverage, security regressions, public examples, handbook guidance, migration notes, and an archived OpenSpec capability.
- Restrict both wheel and source distribution output to the three approved public profile assets; local state, machine enrollment, environment files, Git metadata, and user-specific profiles are excluded.

## CLI surface

Before: setup, doctor, and profile inspection depended on explicit local profile or machine paths.

After: `ai-dlc machine enroll|migrate|status|plan|apply|sync|doctor` manages a pinned portable profile plus local machine binding. Existing explicit setup and doctor paths remain supported for compatibility, and `profile show` composes explicit replacement scopes with enrolled scopes.

## Schema and template migration

- Schema 4 inputs remain supported.
- Schema 5 adds portable profile identity and logical credential requirements without storing credential values.
- The public personal example and machine-binding example replace user-specific packaged content.
- Generated project handbook and workflow maps describe local CLI versus hosted MCP responsibilities and migration behavior.

## Verification

Fresh local required gate on commit `b1e4a67968544db569746c69c647a2d3e43406e2`:

- generated: passed
- format: passed
- lint: passed
- types: passed
- tests: 785 passed

Disposable XDG-isolated enrollment preview/apply/status/plan and real wheel/sdist privacy inspection also passed. Independent complete-branch review findings were resolved through the documented bounded review and adjudication process.

## Remaining work

- Publish the dogfood work item only after exact native workflow status IDs are configured for the designated `sandbox-aidlc` Linear workspace.
- Provider onboarding and discovery, Obsidian create/attach, hosted cloud qualification, live client sessions, behavioral skill evaluation, and release-asset publication remain follow-up work.
