### PR TITLE
docs: define portable framework direction and delivery roadmap

### DIFF
--- a/.ai-dlc/work/component-capability-contract.toml
+++ b/.ai-dlc/work/component-capability-contract.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "component-capability-contract"
+title = "Connect provider roles to tool installation and harness guidance"
+scope = "Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M1. Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.",
+    "Dependencies: none. Follow docs/superpowers/plans/2026-09-05-component-capability-contract.md before implementation.",
+    "CC-01: The resolver SHALL produce stable component requirements for each explicitly selected role, deduplicate installation modules, and report an unresolved provider without silently selecting another provider.",
+    "CC-02: Custom component metadata SHALL be repository-relative, digest-verified, schema-validated data. It SHALL refer to existing installation recipes and SHALL NOT authorize executable commands.",
+    "CC-03: Existing schema-4 configurations SHALL remain valid; component metadata SHALL NOT weaken project checks or silently rebind active work.",
+    "Excluded scope: No package registry, remote downloads, new provider operations, model selection, or changes to finish gates.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/component-capability-contract"
+plan = "docs/superpowers/plans/2026-09-05-component-capability-contract.md"
+roadmap = "docs/roadmap.md"
+tracker = "6ff49327-df8e-4748-a687-64ca9ade8657"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/connected-project-readiness.toml
+++ b/.ai-dlc/work/connected-project-readiness.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "connected-project-readiness"
+title = "Make selected project tools and guidance ready across machines"
+scope = "Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M1. Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.",
+    "Dependencies: component-capability-contract. Follow docs/superpowers/plans/2026-09-05-connected-project-readiness.md before implementation.",
+    "RD-01: Root-aware setup SHALL resolve explicit project and profile selections into required tool modules and guidance, preserving existing no-root command behavior and authored files.",
+    "RD-02: Project readiness SHALL separately identify tool, configuration, credential, and guidance failures with next actions; it SHALL inspect only credential presence and SHALL NOT read secret files automatically.",
+    "RD-03: Equivalent profile/project revisions SHALL resolve equivalent portable requirements with independent local bindings; unsupported capabilities SHALL be explicit.",
+    "Excluded scope: No credential auto-loading, automatic account choice, new client support claim, hosted control plane, or weakening of existing doctor/finish behavior.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/connected-project-readiness"
+plan = "docs/superpowers/plans/2026-09-05-connected-project-readiness.md"
+roadmap = "docs/roadmap.md"
+tracker = "ec81e77e-03fb-494e-aece-be0633f4b5ae"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/design-pm-calibration.toml
+++ b/.ai-dlc/work/design-pm-calibration.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "design-pm-calibration"
+title = "Calibrate UI/UX evaluation and measure its incremental value"
+scope = "Evaluate the delivered Design PM workflow with original cases, human labels, held-out comparisons, and recorded costs. Depends on design-pm-workflow; live runs require a declared experiment budget and human participation."
+requires_spec = false
+spec_reason = "Verification of the preceding Design PM contract, not a behavior change. Any resulting workflow or acceptance-contract change needs its own specification decision."
+acceptance = [
+    "Dependency: design-pm-workflow is usable and its contract is fixed for the experiment; protocol rationale is docs/design/design-pm.md.",
+    "Create original cases covering polished-but-broken, plain-but-usable, brand-constrained, inaccessible, and screenshot-only outputs; preserve human labels and reserve held-out cases.",
+    "Record a dedicated model/harness, repetitions, and time/token budget before live runs without silently spending the existing agents/evaluation.toml budget.",
+    "Compare current guidance, rubric-only generation, and rubric plus independent evaluation on matched tasks; preserve transcripts, candidate/evidence identity, and condition order.",
+    "Report human preference, required defects missed, false positives, rater disagreement, elapsed time, and available usage; human ratings remain pending until supplied by a human.",
+    "Document limitations and recommend keeping, changing, or simplifying the workflow; unsupported clients and unrun cases stay unverified.",
+    "Publish the evidence report through normal repository review and required checks; do not equate fixture tests with live quality improvement.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+plan = "docs/superpowers/plans/2026-09-05-design-pm-calibration.md"
+design = "docs/design/design-pm.md"
+roadmap = "docs/roadmap.md"
+tracker = "7fd110ce-2d64-4442-a34a-7069cb0598d2"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/design-pm-workflow.toml
+++ b/.ai-dlc/work/design-pm-workflow.toml
@@ -1,0 +1,37 @@
+schema = 1
+id = "design-pm-workflow"
+title = "Add optional UI/UX design generation and evaluation workflow"
+scope = "Milestone M2 optional UI/UX workflow consuming product-shaping-workflow and spec-delivery-traceability. Follow docs/superpowers/plans/2026-09-05-design-pm-workflow.md; this ticket does not define the overall framework roadmap."
+requires_spec = true
+spec_reason = "Introduces observable design workflow, evidence, iteration, and managed-asset contracts."
+acceptance = [
+    "Deliver brief, rubric, evaluation, and candidate-selection templates; rationale is docs/design/design-pm.md and formal requirements are openspec/changes/design-pm-workflow.",
+    "Translate vague design goals into criterion IDs, score anchors, observable checks, required evidence, and a declared budget before generation.",
+    "Provide separate generation/evaluation guidance with fresh-session or human fallback; label self-review and unverified interaction checks honestly.",
+    "Keep required failures separate from subjective ratings; preserve candidate revisions, rubric versions, findings, and selection through bounded iteration.",
+    "Integrate existing skills/templates and managed project generation without adding a mandatory service, CLI command, or new finish gate; preserve authored content.",
+    "Provide original calibration examples and a protocol; actual comparison runs belong to design-pm-calibration and remain pending.",
+    "Review proposed design details before implementation, pass required project checks and OpenSpec validation, and link reviewed PR and merged-revision evidence before finish.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+plan = "docs/superpowers/plans/2026-09-05-design-pm-workflow.md"
+spec = "openspec/changes/design-pm-workflow"
+design = "docs/design/design-pm.md"
+roadmap = "docs/roadmap.md"
+tracker = "b4715a51-b64d-49de-bb25-38a97052b096"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/framework-delivery-plan.toml
+++ b/.ai-dlc/work/framework-delivery-plan.toml
@@ -1,0 +1,35 @@
+schema = 1
+id = "framework-delivery-plan"
+title = "Document and sequence the portable framework delivery roadmap"
+scope = "Revise current documentation around the approved framework direction, prepare independently finishable OpenSpec changes and executor plans, and synchronize sandbox backlog tickets and dependencies."
+requires_spec = false
+spec_reason = "Planning and documentation delivery only; runtime and skill behavior changes belong to separate linked capability tickets."
+acceptance = [
+    "Current documentation presents portable setup and replaceable tools/workflows as the core, with UI/UX optional.",
+    "Ten child work items have explicit scope, dependency order, interfaces, file ownership, acceptance, verification, exclusions, and handoff guidance.",
+    "Seven behavior changes are represented by independently finishable OpenSpec changes; three verification items retain honest evidence boundaries.",
+    "Existing SAN-6/SAN-7 tickets are revised in place, new tickets are deduplicated, and native dependency links match docs/planning/delivery-index.json.",
+    "OpenSpec validation, documentation/reference checks, work-record validation, and required project checks pass.",
+    "Planning PR and evidence are linked without marking planned implementation or missing live evidence complete.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+branch = "codex/design-pm-roadmap"
+plan = "docs/superpowers/plans/2026-09-05-framework-delivery.md"
+roadmap = "docs/roadmap.md"
+tracker = "402c879f-ddd3-4693-a37b-6a145489a506"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/framework-delivery-plan.toml
+++ b/.ai-dlc/work/framework-delivery-plan.toml
@@ -26,6 +26,7 @@ branch = "codex/design-pm-roadmap"
 plan = "docs/superpowers/plans/2026-09-05-framework-delivery.md"
 roadmap = "docs/roadmap.md"
 tracker = "402c879f-ddd3-4693-a37b-6a145489a506"
+pr = "https://github.com/Sean-Koval/ai-dlc/pull/5"
 
 [bindings]
 specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"

--- a/.ai-dlc/work/framework-qualification.toml
+++ b/.ai-dlc/work/framework-qualification.toml
@@ -1,0 +1,35 @@
+schema = 1
+id = "framework-qualification"
+title = "Qualify portable setup, provider replacement, and development handoffs"
+scope = "Produce reproducible evidence that the delivered framework works on the initial supported environments and supports one safe provider substitution."
+requires_spec = false
+spec_reason = "Verification of predecessor contracts only; behavior changes discovered during qualification require a separate spec decision."
+acceptance = [
+    "Milestone M3. Produce reproducible evidence that the delivered framework works on the initial supported environments and supports one safe provider substitution.",
+    "Dependencies: connected-project-readiness, linear-provider-onboarding, portable-workflow-bundles, spec-delivery-traceability. Follow docs/superpowers/plans/2026-09-05-framework-qualification.md before implementation.",
+    "Q-01: Demonstrate equivalent portable requirements on both initial targets with independent local bindings and a repeat setup that creates no duplicate owned assets.",
+    "Q-02: Demonstrate a new work cycle using each tracker adapter without changing workflow rationale; existing records stay bound, and unsupported transitions are explicit.",
+    "Q-03: A fresh session completes the next action from project artifacts alone; report tool/client limits and preserve transcripts and receipts for each actual target.",
+    "Excluded scope: No production tracker changes, invented clean-machine evidence, new platform support, package publication, or automatic closure when an environment is unavailable.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+plan = "docs/superpowers/plans/2026-09-05-framework-qualification.md"
+roadmap = "docs/roadmap.md"
+tracker = "18f46d0a-618c-4ebd-a7cc-92b56cff8681"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/linear-provider-onboarding.toml
+++ b/.ai-dlc/work/linear-provider-onboarding.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "linear-provider-onboarding"
+title = "Discover and safely configure a project's Linear connection"
+scope = "Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M1. Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.",
+    "Dependencies: component-capability-contract. Follow docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md before implementation.",
+    "LN-01: Onboarding SHALL query only the configured credential's organization, teams, and workflow states, consume pagination, and report incomplete or failed discovery without mutations.",
+    "LN-02: Onboarding SHALL validate organization, team, and state membership and types before showing a non-secret patch; apply SHALL require unchanged source configuration and preserve unrelated content.",
+    "LN-03: Onboarding SHALL retain the project's credential variable and refuse silent mapping changes for already bound work; it SHALL NOT create or modify remote issues or accounts.",
+    "Excluded scope: No API-key creation, Linear Project creation, issue mutation, organization switching, or automatic rebind. Use existing sandbox only for authorized live reads.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/linear-provider-onboarding"
+plan = "docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md"
+roadmap = "docs/roadmap.md"
+tracker = "6fd7671e-3351-47d0-9c43-6d9537160a1d"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/portable-workflow-bundles.toml
+++ b/.ai-dlc/work/portable-workflow-bundles.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "portable-workflow-bundles"
+title = "Import pinned workflow guidance and expose it to supported harnesses"
+scope = "Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M1. Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.",
+    "Dependencies: component-capability-contract, connected-project-readiness. Follow docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md before implementation.",
+    "WB-01: Imported workflow bundles SHALL record source, exact resolved revision, and complete file digests; preview SHALL leave active project and client files unchanged.",
+    "WB-02: Bundle validation SHALL reject unsafe, undeclared, tampered, or colliding assets before rendering; owned updates SHALL preserve authored modifications.",
+    "WB-03: Selected vendored guidance SHALL be discoverable in supported harnesses and usable offline; instructions SHALL NOT depend on an AI-DLC daemon or prior chat.",
+    "Excluded scope: No arbitrary installer/scripts, marketplace, dependency solver, new client adapter, remote auto-update, or changes to personal profile enrollment semantics.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/portable-workflow-bundles"
+plan = "docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md"
+roadmap = "docs/roadmap.md"
+tracker = "a62d3b79-a8f1-46bb-9c09-7a2af5f0b36d"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/product-shaping-workflow.toml
+++ b/.ai-dlc/work/product-shaping-workflow.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "product-shaping-workflow"
+title = "Guide product discovery and feature selection for new and existing products"
+scope = "Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M2. Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.",
+    "Dependencies: none. Follow docs/superpowers/plans/2026-09-05-product-shaping-workflow.md before implementation.",
+    "PS-01: The workflow SHALL distinguish observed evidence, user decisions, and hypotheses; it SHALL compare feasible options and identify a bounded outcome before proposing implementation.",
+    "PS-02: Greenfield guidance SHALL shape the smallest useful outcome; brownfield guidance SHALL inspect existing behavior and preserve explicit compatibility boundaries.",
+    "PS-03: The workflow SHALL produce traceable outcome/requirement IDs and an explicit proceed, investigate, or stop decision; material unknowns SHALL remain visible and SHALL NOT become invented acceptance facts.",
+    "Excluded scope: No invented interviews or user approval, automatic ticket publication during discovery, mandatory UI work, replacement specification system, or broad autonomous feature expansion.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/product-shaping-workflow"
+plan = "docs/superpowers/plans/2026-09-05-product-shaping-workflow.md"
+roadmap = "docs/roadmap.md"
+tracker = "e6b3cdc5-2b03-4bde-b53a-9be1a48f5d96"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/spec-delivery-traceability.toml
+++ b/.ai-dlc/work/spec-delivery-traceability.toml
@@ -1,0 +1,36 @@
+schema = 1
+id = "spec-delivery-traceability"
+title = "Carry product requirements into independently deliverable specifications and tickets"
+scope = "Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence."
+requires_spec = true
+spec_reason = "Adds observable workflow, integration or guidance behavior; the linked OpenSpec change defines acceptance."
+acceptance = [
+    "Milestone M2. Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.",
+    "Dependencies: product-shaping-workflow. Follow docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md before implementation.",
+    "TR-01: New delivery guidance SHALL map product requirement IDs to formal behavioral scenarios when needed, a deliverable work item, and verification. Scope, rationale, spec, and task list SHALL retain distinct ownership.",
+    "TR-02: Work validation SHALL reject missing or cyclic dependencies and absent referenced artifacts before publication; start SHALL refuse incomplete or unavailable required dependency status.",
+    "TR-03: New issue publication SHALL include scope, references, dependencies, and acceptance while preserving existing correlation/idempotency and authored descriptions on repeat publication.",
+    "Excluded scope: No automatic scope approval, duplicate spec store, spec-to-one-checkbox-ticket mapping, remote priority inference, or weakened finish gates.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+spec = "openspec/changes/spec-delivery-traceability"
+plan = "docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md"
+roadmap = "docs/roadmap.md"
+tracker = "686b5639-dadd-49c2-8a6d-21251e8ad9f7"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.ai-dlc/work/workflow-quality-calibration.toml
+++ b/.ai-dlc/work/workflow-quality-calibration.toml
@@ -1,0 +1,35 @@
+schema = 1
+id = "workflow-quality-calibration"
+title = "Evaluate product shaping and delivery guidance against baseline behavior"
+scope = "Measure whether the general product-to-delivery guidance improves decisions, scope control, and implementation handoff using human-labeled scenarios."
+requires_spec = false
+spec_reason = "Verification of predecessor contracts only; behavior changes discovered during qualification require a separate spec decision."
+acceptance = [
+    "Milestone M3. Measure whether the general product-to-delivery guidance improves decisions, scope control, and implementation handoff using human-labeled scenarios.",
+    "Dependencies: product-shaping-workflow, spec-delivery-traceability. Follow docs/superpowers/plans/2026-09-05-workflow-quality-calibration.md before implementation.",
+    "EV-01: Cases distinguish evidence from assumptions, cover both entry paths, and include correct investigate/stop/no-spec outcomes.",
+    "EV-02: Comparison uses fixed recorded versions/budgets and held-out cases; full transcripts and actual costs/time are preserved where available.",
+    "EV-03: Human labels are supplied by humans; absent ratings remain pending, and results state observed scope without asserting universal model improvement.",
+    "Excluded scope: No fabricated human ratings, automatic paid experiments, universal quality claims, or substitution for existing release evaluations.",
+    "Required checks, source review, and configured merged-revision completion evidence must pass; fixture tests do not establish live qualification.",
+]
+reviewed = true
+
+[providers]
+specs = "openspec"
+tracker = "linear"
+scm = "github"
+knowledge = "obsidian"
+deploy = "none"
+
+[artifacts]
+plan = "docs/superpowers/plans/2026-09-05-workflow-quality-calibration.md"
+roadmap = "docs/roadmap.md"
+tracker = "843b9d21-d321-444d-88dd-353f12a505c2"
+
+[bindings]
+specs = "a8f8f91947ed105b68ab6c04da0b24fa96e4c95b3d0b07f7292fa0e13c6e20e0"
+scm = "23b0865e22fda020405adc9fc56b580f198fa030b0c0136f2b4f1b5942ab0e72"
+deploy = "723f01d121ffcb46ffdacc0bbc45383408acf9aeed65484acafcbe1d72e24160"
+knowledge = "28ca66580437daadd63929abd63c2bedd34b5e0212f2d94a9c8fcd653e711852"
+tracker = "08e58cff6eeb57842d485cdcc8cefeef0ef191438c796ee2db82bb848e4a1b4c"

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ build/
 .ruff_cache/
 .ai-dlc/local/
 .superpowers/
+.worktrees/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # AI-DLC
 
-AI-DLC keeps your development tools, project requirements, agent configuration, and working process in versioned, editable files. Python services power both the CLI and the local MCP server.
+AI-DLC prepares development environments and connects replaceable tools, project
+structure, and workflow guidance so people and agent harnesses can consistently
+improve new and existing products. Versioned profiles and project files carry the
+portable setup; local bindings carry machine-specific choices. Python services
+support the CLI and local MCP server.
+
+The harness can use installed tools directly. AI-DLC supplies setup, integration,
+guidance, and verification where useful; repository policy defines required gates.
+UI/UX design is one optional workflow within the broader product-development process.
+
+See the [product direction](docs/product-direction.md), [delivery roadmap](docs/roadmap.md),
+and [executor handoff](docs/handoffs/framework-delivery.md). Those pages distinguish
+planned capabilities from the implementation available today.
 
 This checkout is a **v4 implementation candidate**. Native macOS Apple silicon bootstrap, a clean ARM64 devcontainer lifecycle, required checks on Linux x64/ARM64 and macOS Intel, Docker provider isolation, and read-only Linear sandbox health have been exercised. Factory-clean macOS, hosted cloud sessions, remaining live integrations, and release publication still require explicit walkthroughs. See [verification status](docs/release-verification.md). There is no published v4 bootstrap release yet.
 

--- a/ai-dlc.toml
+++ b/ai-dlc.toml
@@ -27,8 +27,13 @@ receipt_artifacts = [
 ]
 
 [providers.linear]
-token_env = "LINEAR_API_KEY"
-# Set team_id and workspace-native status UUIDs before publishing work.
+token_env = "LINEAR_SANDBOX_TOKEN"
+team_id = "47b701a4-d6a6-4d27-85fc-6dd42030ddd3"
+health_reference = "2a8b487f-3433-4ebe-a9e2-a16ac5b156da"
+
+[providers.linear.statuses]
+in_progress = "6076dc88-dd2f-4e2e-85aa-aed1a6d36bcf"
+closed = "3e34f09e-e258-4044-b034-8d5dd4e63fb4"
 
 [gates]
 finish = ["specification-current", "pr-merged", "ci-green"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,10 @@
 # Architecture
 
+This page describes the current implementation. The [product direction](product-direction.md)
+and [planned delivery architecture](design/framework-delivery.md) describe the next
+increments. UI/UX is one optional workflow; portable setup, replaceable integrations,
+and effective greenfield/brownfield development remain the framework's core.
+
 AI-DLC v4 runs as a local Python CLI and library. The CLI owns machine
 enrollment mutation; the MCP facade exposes only reviewed work, doctor, and
 knowledge services. Project adoption uses Copier; provider adapters isolate

--- a/docs/design/design-pm.md
+++ b/docs/design/design-pm.md
@@ -1,0 +1,201 @@
+# Design PM: portable briefs, evaluation, and iteration
+
+Owner: AI-DLC project maintainer
+Status: planned optional UI/UX workflow within milestone M2; implementation and live evaluation pending
+Updated: 2026-09-05
+
+This proposal consumes the broader [product-shaping workflow](../../openspec/changes/product-shaping-workflow/proposal.md)
+and [delivery traceability](../../openspec/changes/spec-delivery-traceability/proposal.md).
+The [framework direction](../product-direction.md) owns the product strategy;
+this document owns UI/UX-specific rationale and example evaluation criteria.
+Execution details are in the [implementation plan](../superpowers/plans/2026-09-05-design-pm-workflow.md).
+
+## Problem and audience
+
+AI-DLC equips development harnesses with reproducible tools, repository structure,
+Markdown guidance, and consistent workflows across machines. The harness runs the
+development process. CLI services support setup, validation, traceability, and
+evidence gates where applicable; every development action need not pass through
+the CLI. Existing project completion policies remain in effect.
+
+The intended audience is a developer using a harness such as Codex, Claude Code,
+Antigravity, or Pi to turn a product idea into a usable interface. Current client
+fixtures cover Codex and Claude Code only; this proposal does not establish support
+for the other clients.
+
+Today the repository has discovery, PRD, specification-decision, and handoff
+guidance, plus a design template. It does not supply a complete way to turn a
+design preference into a repeatable evaluation. A request to make an interface
+good leaves the evaluator inventing the target after seeing the result.
+
+## Source and adaptation
+
+Anthropic's [harness-design article](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+uses separate generation and evaluation, four design axes (design quality,
+originality, craft, functionality), example-based evaluator calibration, and
+inspection of running interfaces. Its game-editor example catches rectangle fill
+that places only endpoint tiles. Later experiments simplify orchestration as model
+capability changes. These are experimental findings, not a universal recipe.
+
+The artifact layout, example rubric, thresholds, budgets, and delivery plan below
+are proposed AI-DLC choices. They are not measurements or prescriptions from the
+article.
+
+## Outcomes and acceptance
+
+1. A harness can take a short product request and produce a brief that identifies
+   audience, primary task, constraints, references, and observable success.
+2. Before generation, the work has a versioned rubric with criterion IDs, evidence
+   methods, score anchors, required checks, and an explicit evaluation budget.
+3. A fresh evaluator can inspect an identified candidate and produce actionable
+   findings without receiving the generator's self-rating as its evidence.
+4. A later session or another supported harness can continue from the saved brief,
+   rubric, candidate, findings, and unresolved decisions.
+5. Deterministic failures, subjective ratings, and missing evidence remain distinct.
+   A high visual rating cannot compensate for a failed required user journey.
+6. A separate calibration exercise measures whether the workflow improves human
+   preference and defect detection enough to justify its cost.
+
+## Scope and exclusions
+
+The first delivery is a portable workflow package: skill guidance, templates,
+examples, and project-generation integration. The two skills are design-brief
+for brief/rubric creation and design-evaluate for independent review. Generation
+uses the selected existing visual tool or skill.
+Reuse the existing discovery and PRD stages; Design PM supplies their design-specific
+verification detail. Existing visual-design tools can perform generation.
+
+No mandatory orchestration daemon, new hosted service, hard-coded model, or fixed
+three-agent process is required. One harness can sequence separate sessions or
+use its native delegation if available. A human can perform independent review.
+When independence is unavailable, record self-review explicitly.
+
+This change does not add UI code to AI-DLC, change its finish gates, install new
+client integrations, introduce a credential loader, or require a new CLI command.
+Automation is a later option if the manual artifact workflow proves useful.
+
+## Proposed workflow
+
+1. **Brief:** capture users, intended tasks, scope, constraints, style references,
+   existing design-system commitments, and unresolved product decisions.
+2. **Evaluation contract:** translate the brief into checks and rating anchors;
+   identify viewports, states, fixture data, evidence, reviewers, and budget.
+3. **Generate:** create an identified candidate against that brief and contract.
+4. **Evaluate:** a separate reviewer exercises the candidate, records evidence,
+   and ties each finding to a criterion and reproducible state.
+5. **Iterate:** address prioritized findings, retest affected behavior, and retain
+   the previous candidate so selection can favor an earlier revision.
+6. **Select and hand off:** record the chosen candidate, residual findings, and
+   human decisions; use `needs-spec` and OpenSpec for implementation behavior.
+
+Design iteration can overlap implementation. The selected artifact and evaluation
+contract travel with the work; they do not replace regression tests or repository
+completion policy.
+
+## Starter rubric: an onboarding interface example
+
+These examples describe a hypothetical interface for a developer tool, not an
+existing AI-DLC UI. Projects adapt them before running an evaluation.
+
+| Axis | Concrete example criterion | Evidence |
+| --- | --- | --- |
+| Design quality | Connection, review, and success screens use the same named text styles and action hierarchy; the current setup step is identifiable on each. | Screenshots of all three states with marked inconsistencies. |
+| Originality | Workspace selection uses relevant identity and permission details; decorative dashboard panels do not displace the user's connection task. Existing brand components are welcome when they fit the brief. | Compare the candidate with the brief and explain specific choices. |
+| Craft | At the agreed mobile and desktop widths, long workspace names do not obscure the primary action; visible keyboard focus is not clipped or covered. | Browser inspection with long-name fixtures and keyboard traversal. |
+| Functionality | Starting disconnected, a user selects the intended workspace, reviews the selection, and reaches a working connected state. A rejected credential permits correction without silently switching workspaces. | Reproducible interaction trace and observed application state. |
+
+Every subjective criterion uses a proposed 0–4 scale: 0 contradicts the criterion;
+1 has major shortcomings; 2 partly meets it; 3 meets it with evidence; 4 exceeds
+it in a way that serves the brief. Each criterion needs its own examples of 1,
+3, and 4; the generic scale alone is insufficient calibration. Missing observation
+is `unverified`, not a zero or a passing score.
+
+Starter selection rule: all required behavioral checks pass, each required rated
+criterion reaches 3, and no required evidence is missing. These are unvalidated
+starting defaults. A project can choose different thresholds before the run.
+Optional weighted scores rank candidates only after required checks pass.
+An existing enterprise design system can prioritize consistency; originality does
+not require novelty, unusual navigation, or a new component library.
+
+Each check records an ID, applicable state, setup, action, expected observation,
+method, severity, and evidence location. For example:
+
+- `FLOW-01`: Given two similarly named workspaces, select the second, review its
+  identifier, connect, reload, and verify that the second remains selected.
+- `RECOVERY-01`: Reject a credential, correct it, and retry; verify the error clears
+  and no duplicate connection or unintended workspace selection appears.
+- `KEYBOARD-01`: Perform the primary journey using only keyboard controls; verify
+  reachable controls, visible focus, and focus restoration after closing a dialog.
+- `NARROW-01`: At the agreed narrow viewport, open validation feedback with a long
+  workspace name; verify the message and retry control remain visible and usable.
+
+These are acceptance examples, not a complete accessibility compliance assessment.
+Static mockups can support visual review but leave interaction checks unverified.
+
+## Artifacts and ownership
+
+Suggested project paths (created when a design task needs them):
+
+- `docs/design/<work-id>/brief.md`: rationale, audience, scope, references.
+- `docs/design/<work-id>/rubric.md`: versioned criteria and example anchors.
+- `docs/design/<work-id>/iterations/<candidate-id>/evaluation.md`: revision,
+  tools/model, criteria version, observations, scores, findings, and verdict.
+- `docs/design/<work-id>/decision.md`: chosen candidate, rationale, remaining gaps.
+
+Evidence links identify the candidate revision, viewport, fixture, and capture.
+Use repository-approved storage for recordings and screenshots; exclude secrets
+and private user data. The report records an evidence digest or immutable artifact
+reference. Formal requirements stay in OpenSpec. Linear stores work status and
+priority. These Markdown artifacts are usable directly by the selected harness.
+
+## Iteration and evaluation of the workflow
+
+Proposed starter budget: one initial candidate plus at most two revision rounds,
+with a project-selected time or token ceiling recorded before execution. Stop on
+meeting the contract, exhausting the budget, a material product decision, or two
+consecutive evaluations with no criterion improvement and no required defect
+resolved. Plateau can end the run without success. Preserve the best candidate
+that meets the contract; record `needs-work` when none does. Human overrides are
+recorded and cannot relabel a failed test or supply absent evidence.
+
+Evaluate the evaluator as well as the UI. Build original calibration cases that
+include a polished but broken journey, a plain usable interface, a deliberate
+brand constraint, an inaccessible interaction, and a screenshot-only mockup.
+Have humans label defects and explain taste preferences before tuning prompts.
+Reserve held-out cases to detect overfitting.
+
+Compare (a) current guidance, (b) rubric-only generation, and (c) rubric plus
+independent evaluation on matched tasks and fixed recorded budgets. Record human
+pairwise preference, missed required defects, false-positive findings, rater
+disagreement, actual usage when available, and elapsed time. Counterbalance order
+and hide condition labels from human raters where practical. Repeat runs; do not
+claim general improvement from one favorable example. Keep human review pending
+until a human supplies it.
+
+`agents/evaluation.toml` currently describes evaluations of AI-DLC's judgment
+skills, not this UI workflow. Preserve its existing protocol and budget; the
+Design PM experiment needs its own declared cases and budget.
+
+## Constraints, risks, and open questions
+
+- Score gaming: keep examples and criteria stable during a comparison; a material
+  rubric change creates a new version and requires rescoring retained candidates.
+- Aesthetic bias: use project-specific references and human calibration; do not
+  treat one evaluator's preference as objective beauty.
+- Missing tools: preserve portable instructions and report unverified checks when
+  a harness cannot inspect the required browser state.
+- Portability claims: separately qualify each client; readable Markdown alone
+  does not prove hooks, browser tools, or delegation work on that client.
+- The execution plan fixes skill names and the Markdown artifact contract. Each
+  design task chooses brand references, accessibility target, and run budget
+  before evaluation; these are task inputs rather than unresolved framework scope.
+
+## Links
+
+- [Roadmap](../roadmap.md)
+- [Current design handoff](../workflows/design-to-implementation.md)
+- [Formal proposal](../../openspec/changes/design-pm-workflow/proposal.md)
+- [Implementation work record](../../.ai-dlc/work/design-pm-workflow.toml)
+- [Calibration work record](../../.ai-dlc/work/design-pm-calibration.toml)
+- [SAN-6: workflow backlog ticket](https://linear.app/sandbox-aidlc/issue/SAN-6/add-portable-design-pm-briefs-rubrics-and-evaluation-workflow)
+- [SAN-7: calibration backlog ticket](https://linear.app/sandbox-aidlc/issue/SAN-7/calibrate-design-pm-evaluation-and-measure-quality-versus-cost)

--- a/docs/design/framework-delivery.md
+++ b/docs/design/framework-delivery.md
@@ -1,0 +1,104 @@
+# Framework delivery architecture
+
+Status: planned implementation contracts, September 5, 2026.
+Authority: [product direction](../product-direction.md). Formal behavior belongs
+to the linked OpenSpec changes.
+
+## Baseline and intended change
+
+The current Python implementation has installation modules, scoped configuration,
+provider adapters, managed client files, work records, and finish gates. These
+primitives need a connected role-to-tool-to-guidance readiness experience.
+Product-shaping instructions also need concrete examples and verification.
+
+Keep existing services. Add small boundaries where responsibilities are currently
+disconnected: provider role → component → existing modules, guidance, configuration.
+Provider code continues to own remote operations and evidence interpretation.
+
+## Ticket boundaries
+
+| Work ID | Owns | Excludes |
+| --- | --- | --- |
+| component-capability-contract | Pure metadata validation and resolution | Installation, network, remote mutation |
+| connected-project-readiness | Provisioning composition, guidance index, scoped readiness | Account selection, platform certification |
+| linear-provider-onboarding | Discovery and reviewed local configuration | Issues, keys, automatic account switching |
+| portable-workflow-bundles | Pinned Markdown import and owned distribution | Arbitrary installers and orchestration |
+| product-shaping-workflow | Evidence, alternatives, scope, requirement IDs | Formal-spec ownership, publication during discovery |
+| spec-delivery-traceability | Work graph, references, validation, initial ticket body | Product decisions |
+| design-pm-workflow | Optional UI/UX rubric and evaluation | Framework-wide workflow policy |
+| framework-qualification | Target, replacement, continuity evidence | New platform support by assertion |
+| workflow-quality-calibration | Product/delivery decision evaluations | UI taste calibration |
+| design-pm-calibration | UI evaluator's incremental value | General environment qualification |
+
+## Frozen cross-ticket contracts
+
+1. Retain schema 4 with additive nested fields. Component overrides use
+   `providers.<id>.component`, `component_manifest`, and
+   `component_manifest_sha256`. Machine layers cannot set them. Imported
+   `agents.bundles` is project-only initially. Absent fields preserve old behavior.
+2. Resolve explicit project/profile choices with provenance. Compatibility-only
+   defaults do not authorize installation. Union required modules without rewriting
+   the personal profile.
+3. Component schema 1 contains `id`, `roles`, `modules`, `guidance`, and
+   `required_config`. Recipes remain in `modules/catalog.toml`; built-in guidance
+   lives in `agents/providers/`. Custom metadata is checked-in hashed JSON with
+   existing recipe references and no executable installation commands.
+4. Offline readiness uses tool, configuration, credential, and guidance checks.
+   Provider health is informational unless explicitly inspected. Report
+   ready/missing/blocked/unverified with a next action and
+   `qualification = not-assessed`. Preserve existing doctor enrollment failures.
+5. Linear onboarding uses the selected environment reference. Apply consumes the
+   saved non-secret preview after fresh membership and source-digest checks.
+   Bound work needs explicit rebind. Do not auto-read secret files or guess states.
+6. Workflow bundles contain regular Markdown from a reviewed Git source/ref.
+   Vendor selected files and a lock with exact commit and hashes. Preview and
+   owned updates preserve authored files. Offline use never fetches.
+7. Future Work fields `depends_on` and `requirements` have empty-list defaults.
+   They are not valid in today's Work schema. Current plans and Linear
+   relationships therefore carry dependencies until the traceability ticket lands.
+8. Each behavior ticket owns an independently finishable OpenSpec change.
+   Verification tickets use `requires_spec = false`; changing a predecessor's
+   behavior requires a new specification decision.
+
+Exact service signatures, file ownership, refusal cases, and sample regressions
+are in the [execution plans](../superpowers/plans/2026-09-05-framework-delivery.md).
+Dependent tickets must consume those interfaces rather than invent alternatives.
+
+Implementation clarifications:
+
+- Component loading owns filesystem/digest checks; pure resolution receives its
+  validated catalog. Use `load_component_catalog(root: Path, config: dict) -> dict`
+  in components.py, with packaged defaults through the existing assets helper.
+  Explicit-role filtering uses `Resolved.sources`: personal/project selections
+  count; compatibility-only base defaults do not trigger new installation.
+- Linear plan `config` is the parsed shared ai-dlc.toml, not merged machine state.
+  `before_digest` uses the existing canonical `config.digest` on that dictionary.
+  Apply re-reads/parses the current file and compares the same digest. Comment-only
+  changes survive because editing starts from the current file text, never from a
+  reserialization of the old dictionary. Invalid plans write nothing.
+- A bundle candidate is a context-managed `BundleCandidate` dataclass in
+  workflow_bundles.py with `source: str`, `ref: str`, `bundle_id: str`,
+  `resolved_commit: str`, `root: Path`, `manifest: dict`, and
+  `file_hashes: dict[str, str]`. `root` is temporary reviewed content. Exiting its
+  context cleans temporary content; import copies validated bytes to owned
+  project storage before exit. Revalidate file hashes immediately before copying.
+
+## Agent execution and proportional effort
+
+A ticket is the unit of independently reviewed delivery. Its OpenSpec tasks and
+plan checkboxes are smaller steps inside it. Use installed tools directly for
+development and the current services where repository policy requires them.
+
+Skill delivery includes worked examples and decision cases. A small change can
+use one brief or evaluation report if it carries the required evidence. Do not
+generate every template or always spawn multiple agents.
+
+## Rollout and evidence
+
+M1/M2 ship additive behavior with focused regressions and required checks. M3
+measures their integrated outcomes on explicitly named environments. Unavailable
+targets leave qualification unfinished. Human ratings and paid experiments
+require actual participation and a declared budget.
+
+A documentation PR, generated fixture, live run, and human evaluation establish
+different evidence. Original v4 release gates remain separately tracked.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -5,6 +5,17 @@ development stages and their evidence contracts. Tool names are kept in the
 [tool map](workflows/tool-map.md) so providers can change without redefining the
 lifecycle.
 
+AI-DLC prepares tools, structure, and guidance for the chosen harness. Agents can
+invoke installed provider tools directly. The services below own specific
+validation and lifecycle boundaries; they do not mediate every development action.
+See [product direction](product-direction.md) and the [roadmap](roadmap.md) for
+planned capabilities.
+
+Product requirements explain outcomes, specifications define behavior, tickets
+organize deliverable slices, and tasks describe implementation steps. Link these
+artifacts through stable references. UI/UX evaluation is an optional branch;
+other work uses its own appropriate verification methods.
+
 Use the [greenfield guide](workflows/greenfield.md) for a new application and
 the [brownfield guide](workflows/brownfield.md) for an existing repository. The
 [design-to-implementation guide](workflows/design-to-implementation.md) defines

--- a/docs/handoffs/framework-delivery.md
+++ b/docs/handoffs/framework-delivery.md
@@ -1,0 +1,72 @@
+# Framework delivery: executor handoff
+
+Objective: deliver the [approved direction](../product-direction.md) using the
+dependency-ordered [roadmap](../roadmap.md). UI/UX is one optional part.
+
+## Current state
+
+- Planning branch: `codex/design-pm-roadmap`.
+- Implementation baseline: `241e715`, portable profile enrollment merged into main.
+- This planning delivery adds documentation, specifications, work records, and
+  sandbox ticket bindings. It does not implement the planned commands or skills.
+- Original v4 change remains 10/14 tasks complete; missing release evidence is not waived.
+- Machine enrollment was absent at the September 5 review. Project bootstrap and
+  Linear health do not establish complete machine enrollment.
+- See the planning ticket/PR for the final commit and fresh validation evidence.
+
+## Start here
+
+1. Read `AGENTS.md`, `ai-dlc.toml`, product direction, and the master plan.
+2. Ensure the planning branch is reviewed and integrated before branching a feature
+   from main; do not rely on missing uncommitted files.
+3. Default first ticket: `component-capability-contract`.
+   `product-shaping-workflow` is independently ready for a product-guidance owner.
+4. Read the selected work record, whole OpenSpec change, and exact execution plan.
+   Confirm current tracker status and completed dependencies before work.
+5. Prepare with `sh scripts/bootstrap.sh --source`; use its printed PATH directories.
+   Credentials are independently injected in the selected local environment.
+6. Start/bind only the selected ticket using the branch procedure below. Implement one plan task at a time with
+   regression evidence, source/generated updates, and scope review.
+7. Complete focused and required checks, review, specification archive where
+   required, PR/CI, merge, and `ai-dlc work finish <id>`.
+
+### Exact first-ticket start
+
+After the planning change is integrated and the checkout is clean and up to date,
+use the existing commands below. The explicit branch link avoids the CLI's older
+default `work/` branch prefix. Inject credentials through the selected environment;
+these commands do not load a secret file automatically.
+
+```sh
+ai-dlc work link component-capability-contract branch codex/component-capability-contract
+ai-dlc work start component-capability-contract
+```
+
+For a different ready ticket, substitute its work ID in both commands and use
+`codex/<work-id>` for its branch. Do not republish an already bound ticket to edit
+its title or description: publishing is reconciliation, not a metadata editor.
+
+## Invariants
+
+- The harness can use installed tools directly; AI-DLC makes the workflow available
+  and consistent while preserving configured checks and finish policy.
+- Tool selection connects to installation, configuration, instructions, and readiness.
+- Product evidence differs from hypotheses. Specifications define behavior;
+  tickets organize deliverable slices; checkboxes describe implementation steps.
+- Credentials never enter tracked files, output, or tickets. Provider changes do
+  not silently redirect existing work.
+- Do not add future `depends_on`/`requirements` fields to current Work records
+  until the traceability ticket supports them. Check plans and Linear relationships.
+- Sample regressions and expected new files in plans are future implementation
+  instructions, not evidence that those tests exist or have passed.
+
+## Blockers and continuation
+
+Report the exact blocker if an accepted interface conflicts with current behavior,
+a dependency is unfinished, a live target is unavailable, or human ratings/budget
+are absent. Continue independent preparation when possible. Do not invent evidence
+or expand scope to make a blocker disappear.
+
+Each handoff records work/ticket ID, branch/revision, delivered interfaces, spec and
+plan links, actual verification outcomes, evidence locations, unresolved findings,
+and next eligible task. The next agent should need those artifacts, not this chat.

--- a/docs/handoffs/framework-delivery.md
+++ b/docs/handoffs/framework-delivery.md
@@ -6,6 +6,8 @@ dependency-ordered [roadmap](../roadmap.md). UI/UX is one optional part.
 ## Current state
 
 - Planning branch: `codex/design-pm-roadmap`.
+- Planning review: [PR #5](https://github.com/Sean-Koval/ai-dlc/pull/5), draft at
+  handoff; [validation evidence](../planning/framework-delivery-review.md).
 - Implementation baseline: `241e715`, portable profile enrollment merged into main.
 - This planning delivery adds documentation, specifications, work records, and
   sandbox ticket bindings. It does not implement the planned commands or skills.

--- a/docs/implementation-v4.md
+++ b/docs/implementation-v4.md
@@ -2,6 +2,11 @@
 
 Authority: the user-approved AI-DLC v4 plan, September 2, 2026.
 
+This is a historical implementation ledger. Its progress notes describe that
+implementation period; use the [current roadmap](roadmap.md) and
+[release evidence](release-verification.md) for present status. Preserve the
+original v4 verification obligations when planning new capabilities.
+
 ## Global constraints
 
 CLI and MCP share application services. Completion requires trusted CI evidence for

--- a/docs/planning/delivery-index.json
+++ b/docs/planning/delivery-index.json
@@ -1,0 +1,232 @@
+{
+  "schema": 1,
+  "direction": "docs/product-direction.md",
+  "master_plan": "docs/superpowers/plans/2026-09-05-framework-delivery.md",
+  "tickets": [
+    {
+      "id": "component-capability-contract",
+      "title": "Connect provider roles to tool installation and harness guidance",
+      "milestone": "M1",
+      "depends_on": [],
+      "requires_spec": true,
+      "spec": "openspec/changes/component-capability-contract",
+      "plan": "docs/superpowers/plans/2026-09-05-component-capability-contract.md",
+      "work": ".ai-dlc/work/component-capability-contract.toml",
+      "requirements": [
+        "CC-01",
+        "CC-02",
+        "CC-03"
+      ],
+      "tracker": {
+        "id": "6ff49327-df8e-4748-a687-64ca9ade8657",
+        "identifier": "SAN-9",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-9/connect-provider-roles-to-tool-installation-and-harness-guidance"
+      }
+    },
+    {
+      "id": "connected-project-readiness",
+      "title": "Make selected project tools and guidance ready across machines",
+      "milestone": "M1",
+      "depends_on": [
+        "component-capability-contract"
+      ],
+      "requires_spec": true,
+      "spec": "openspec/changes/connected-project-readiness",
+      "plan": "docs/superpowers/plans/2026-09-05-connected-project-readiness.md",
+      "work": ".ai-dlc/work/connected-project-readiness.toml",
+      "requirements": [
+        "RD-01",
+        "RD-02",
+        "RD-03"
+      ],
+      "tracker": {
+        "id": "ec81e77e-03fb-494e-aece-be0633f4b5ae",
+        "identifier": "SAN-10",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-10/make-selected-project-tools-and-guidance-ready-across-machines"
+      }
+    },
+    {
+      "id": "linear-provider-onboarding",
+      "title": "Discover and safely configure a project's Linear connection",
+      "milestone": "M1",
+      "depends_on": [
+        "component-capability-contract"
+      ],
+      "requires_spec": true,
+      "spec": "openspec/changes/linear-provider-onboarding",
+      "plan": "docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md",
+      "work": ".ai-dlc/work/linear-provider-onboarding.toml",
+      "requirements": [
+        "LN-01",
+        "LN-02",
+        "LN-03"
+      ],
+      "tracker": {
+        "id": "6fd7671e-3351-47d0-9c43-6d9537160a1d",
+        "identifier": "SAN-11",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-11/discover-and-safely-configure-a-projects-linear-connection"
+      }
+    },
+    {
+      "id": "portable-workflow-bundles",
+      "title": "Import pinned workflow guidance and expose it to supported harnesses",
+      "milestone": "M1",
+      "depends_on": [
+        "component-capability-contract",
+        "connected-project-readiness"
+      ],
+      "requires_spec": true,
+      "spec": "openspec/changes/portable-workflow-bundles",
+      "plan": "docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md",
+      "work": ".ai-dlc/work/portable-workflow-bundles.toml",
+      "requirements": [
+        "WB-01",
+        "WB-02",
+        "WB-03"
+      ],
+      "tracker": {
+        "id": "a62d3b79-a8f1-46bb-9c09-7a2af5f0b36d",
+        "identifier": "SAN-12",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-12/import-pinned-workflow-guidance-and-expose-it-to-supported-harnesses"
+      }
+    },
+    {
+      "id": "product-shaping-workflow",
+      "title": "Guide product discovery and feature selection for new and existing products",
+      "milestone": "M2",
+      "depends_on": [],
+      "requires_spec": true,
+      "spec": "openspec/changes/product-shaping-workflow",
+      "plan": "docs/superpowers/plans/2026-09-05-product-shaping-workflow.md",
+      "work": ".ai-dlc/work/product-shaping-workflow.toml",
+      "requirements": [
+        "PS-01",
+        "PS-02",
+        "PS-03"
+      ],
+      "tracker": {
+        "id": "e6b3cdc5-2b03-4bde-b53a-9be1a48f5d96",
+        "identifier": "SAN-13",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-13/guide-product-discovery-and-feature-selection-for-new-and-existing"
+      }
+    },
+    {
+      "id": "spec-delivery-traceability",
+      "title": "Carry product requirements into independently deliverable specifications and tickets",
+      "milestone": "M2",
+      "depends_on": [
+        "product-shaping-workflow"
+      ],
+      "requires_spec": true,
+      "spec": "openspec/changes/spec-delivery-traceability",
+      "plan": "docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md",
+      "work": ".ai-dlc/work/spec-delivery-traceability.toml",
+      "requirements": [
+        "TR-01",
+        "TR-02",
+        "TR-03"
+      ],
+      "tracker": {
+        "id": "686b5639-dadd-49c2-8a6d-21251e8ad9f7",
+        "identifier": "SAN-14",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-14/carry-product-requirements-into-independently-deliverable"
+      }
+    },
+    {
+      "id": "design-pm-workflow",
+      "title": "Add optional UI/UX design generation and evaluation workflow",
+      "milestone": "M2",
+      "depends_on": [
+        "product-shaping-workflow",
+        "spec-delivery-traceability"
+      ],
+      "requires_spec": true,
+      "spec": "openspec/changes/design-pm-workflow",
+      "plan": "docs/superpowers/plans/2026-09-05-design-pm-workflow.md",
+      "work": ".ai-dlc/work/design-pm-workflow.toml",
+      "requirements": [
+        "DP-01",
+        "DP-02",
+        "DP-03",
+        "DP-04",
+        "DP-05",
+        "DP-06"
+      ],
+      "tracker": {
+        "id": "b4715a51-b64d-49de-bb25-38a97052b096",
+        "identifier": "SAN-6",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-6/add-optional-uiux-design-generation-and-evaluation-workflow"
+      }
+    },
+    {
+      "id": "framework-qualification",
+      "title": "Qualify portable setup, provider replacement, and development handoffs",
+      "milestone": "M3",
+      "depends_on": [
+        "connected-project-readiness",
+        "linear-provider-onboarding",
+        "portable-workflow-bundles",
+        "spec-delivery-traceability"
+      ],
+      "requires_spec": false,
+      "spec": null,
+      "plan": "docs/superpowers/plans/2026-09-05-framework-qualification.md",
+      "work": ".ai-dlc/work/framework-qualification.toml",
+      "requirements": [
+        "Q-01",
+        "Q-02",
+        "Q-03"
+      ],
+      "tracker": {
+        "id": "18f46d0a-618c-4ebd-a7cc-92b56cff8681",
+        "identifier": "SAN-15",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-15/qualify-portable-setup-provider-replacement-and-development-handoffs"
+      }
+    },
+    {
+      "id": "workflow-quality-calibration",
+      "title": "Evaluate product shaping and delivery guidance against baseline behavior",
+      "milestone": "M3",
+      "depends_on": [
+        "product-shaping-workflow",
+        "spec-delivery-traceability"
+      ],
+      "requires_spec": false,
+      "spec": null,
+      "plan": "docs/superpowers/plans/2026-09-05-workflow-quality-calibration.md",
+      "work": ".ai-dlc/work/workflow-quality-calibration.toml",
+      "requirements": [
+        "EV-01",
+        "EV-02",
+        "EV-03"
+      ],
+      "tracker": {
+        "id": "843b9d21-d321-444d-88dd-353f12a505c2",
+        "identifier": "SAN-16",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-16/evaluate-product-shaping-and-delivery-guidance-against-baseline"
+      }
+    },
+    {
+      "id": "design-pm-calibration",
+      "title": "Calibrate UI/UX evaluation and measure its incremental value",
+      "milestone": "M3",
+      "depends_on": [
+        "design-pm-workflow"
+      ],
+      "requires_spec": false,
+      "spec": null,
+      "plan": "docs/superpowers/plans/2026-09-05-design-pm-calibration.md",
+      "work": ".ai-dlc/work/design-pm-calibration.toml",
+      "requirements": [
+        "DE-01",
+        "DE-02",
+        "DE-03"
+      ],
+      "tracker": {
+        "id": "7fd110ce-2d64-4442-a34a-7069cb0598d2",
+        "identifier": "SAN-7",
+        "url": "https://linear.app/sandbox-aidlc/issue/SAN-7/calibrate-uiux-evaluation-and-measure-its-incremental-value"
+      }
+    }
+  ]
+}

--- a/docs/planning/framework-delivery-review.md
+++ b/docs/planning/framework-delivery-review.md
@@ -1,0 +1,51 @@
+# Framework planning delivery: review evidence
+
+Date: 2026-09-05. Scope: documentation, specifications, work records and sandbox
+backlog preparation. This is not implementation or release qualification.
+
+## Delivered artifacts
+
+- Product direction, current/planned architecture boundaries, and revised source
+  and generated-project handbook guidance.
+- Ten delivery plans, seven independently finishable behavior changes, three
+  verification tickets, and one separate planning work record.
+- Dependency-ordered roadmap, machine-readable delivery index, and executor
+  handoff with starting commands and evidence rules.
+- Eight new delivery tickets and the two existing UI tickets updated in place.
+  SAN-8 separately tracks this planning delivery.
+
+## Observed validation
+
+| Check | Result | Evidence scope |
+| --- | --- | --- |
+| Source bootstrap | Passed | Prepared the current local checkout; not a factory-clean machine |
+| Required project checks | All five passed | Generated assets, formatting, lint, types, tests |
+| Test suite | 785 passed in 204.17 seconds | Existing local suite, not future acceptance examples |
+| Strict OpenSpec validation | 9 passed, 0 failed | Seven roadmap changes, retained v4 change, existing enrollment spec |
+| Work/reference audit | Passed | 11 work records; artifact existence; requirement-to-plan/spec coverage; declared test paths; 137 local Markdown references, including template output targets |
+| Local dependency graph | Passed | 10 delivery nodes, 14 directed edges, no missing nodes or cycles |
+| Linear read-back | Passed | Exact titles, execution-plan links, Backlog status for all ten delivery items, and all 14 native blocking relationships |
+| Credential boundary | Preserved | Secret file remains ignored; shared configuration stores only environment reference and non-secret sandbox mappings |
+
+The required-check receipt is local at
+`.ai-dlc/local/framework-delivery-checks.json`. It records baseline commit
+`241e7151e380b21bf5aacacef12a242721c6dcf5` with `dirty = true` because checks ran
+against the planning working tree. It is not a clean merged-revision CI receipt.
+Later edits were planning prose, task alignment, requirement labels and review
+metadata; strict specification/reference checks were repeated.
+
+Linear identity discovery returned the intended sandbox organization and only
+the expected team. This is observed discovery scope, not proof of every possible
+server-side permission restriction. Ticket metadata was re-read after mutation.
+
+## Review and remaining work
+
+The planning change still needs normal review/merge/CI before SAN-8 can finish.
+No child implementation ticket was started or completed. Proposed commands,
+component schemas, skills, bundle behavior and evaluation protocols remain
+future work. Original v4 release tasks and missing human/live evidence remain
+open under their existing contracts.
+
+Start implementation from the [executor handoff](../handoffs/framework-delivery.md)
+after this planning change is integrated. SAN-9 is the default first ticket;
+SAN-13 is independently ready for a product-guidance owner.

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -1,0 +1,96 @@
+# AI-DLC product direction
+
+Status: approved direction from the maintainer's September 5, 2026 review and
+documentation/delivery request. Roadmap capabilities are planned work, not claims
+that they already ship.
+
+## Product promise
+
+AI-DLC prepares a development environment, connects the user's preferred tools,
+and equips the chosen harness with a consistent way to take a new product or an
+existing product through a verified improvement.
+
+Its durable value is the relationship between tools, artifacts, decisions, and
+workflows. OpenSpec currently provides formal specification, Linear provides
+tracking, and Codex/Claude Code are the implemented client adapters. Those choices
+are replaceable. Stable responsibilities survive provider changes.
+
+The harness performs development and can use installed tools directly. AI-DLC
+provides setup, guidance, integration, validation, and evidence services where
+useful. Existing project policies still determine required checks and completion.
+
+## User outcomes
+
+1. Enroll another supported machine/environment and recover the same selected
+   tools and guidance with independent local credentials, paths, and accounts.
+2. Open a new or existing repository and let the harness discover selected
+   providers, installed tools, authoritative instructions, artifacts, and next action.
+3. Shape a vague idea or observed problem into a worthwhile bounded increment,
+   with evidence, assumptions, alternatives, and explicit success criteria.
+4. Translate outcomes into behavioral specifications, deliverable tickets, and
+   verification without repeatedly copying the same information.
+5. Add or replace components with clear compatibility, ownership, and update rules.
+6. Evaluate delivered products and the guidance used to produce them.
+
+## Responsibilities and replaceability
+
+| Part | Stable responsibility | Current foundation | Next delivery |
+| --- | --- | --- | --- |
+| Environment | Reproduce tools and local bindings | Bootstrap, enrollment, native recipes, project setup | Connect roles to required modules and readiness |
+| Integrations | Connect capabilities to selected systems | Provider registry, contracts, configuration | Component metadata and scoped onboarding |
+| Harness support | Expose tools, guidance, and context | Managed Codex/Claude assets and optional MCP definitions | Provider guidance index and pinned Markdown bundles |
+| Workflows | Guide decisions and handoffs | Discovery/PRD/spec skills and project guides | Worked product-shaping and delivery-slice workflows |
+| Evaluation | Establish achieved outcomes | Checks, gates, pending skill experiments | Target walkthroughs and product/design comparisons |
+
+## Product development workflow
+
+Greenfield starts with audience, problem, evidence, alternatives, and the smallest
+useful outcome. Brownfield starts with observed behavior, users, integrations,
+compatibility constraints, and an incremental change. Both converge on a shaped
+outcome, requirements, applicable design, behavioral specification, delivery
+slices, implementation, and verification. Findings can send work back to discovery.
+
+Product requirements explain intent and scope. Specifications define observable
+behavior. Tickets organize deliverable slices, dependencies, and status. Tasks
+describe implementation steps. Links and stable IDs preserve these relationships.
+
+UI/UX is one optional workflow in this sequence. Its generation/evaluation loop
+serves changes requiring interaction or visual judgment. Other work uses suitable
+methods: compatibility tests, architecture review, migration rehearsals, API
+contracts, or operational evidence. Small work uses small artifacts.
+
+## Principles and limits
+
+- Prefer existing tools; build integration where it removes coordination work.
+  Prove a small component contract with real adapters before expanding it.
+- Make installation, configuration, instructions, and readiness understandable
+  together while preserving their separate data ownership.
+- Carry portable state through versioned repositories; keep secrets and machine
+  bindings local. Never infer an account from an unrelated session.
+- Preserve authored content, active bindings, and existing contracts on updates.
+- Make product choices explicit before coding; an executor must not invent scope,
+  approval, evidence, or a missing cross-ticket interface.
+- Measure observed outcomes. Green tests alone do not prove product value, user
+  preference, or successful live platform qualification.
+- Consistency means the same intended workflow with honest capability differences,
+  not an assertion that every environment supports every tool.
+
+## Delivery boundaries
+
+Initial qualification targets: native macOS arm64 and an Ubuntu 24.04 arm64
+devcontainer. Each remains unverified until its actual walkthrough succeeds.
+Hosted platforms, extra harness adapters, executable workflow packages, knowledge
+onboarding, and release publication remain separately scoped follow-ons.
+
+The code remains a v4 implementation candidate. Original v4 release tasks remain
+open where evidence is missing; this roadmap does not relabel that work.
+
+## Navigation
+
+- [Roadmap](roadmap.md)
+- [Delivery architecture](design/framework-delivery.md)
+- [Executor handoff](handoffs/framework-delivery.md)
+- [V4 proposal](../openspec/changes/portable-development-v4/proposal.md)
+- [Enrollment design and follow-on cycles](superpowers/specs/2026-09-03-portable-profile-enrollment-design.md)
+- [Current architecture](architecture.md)
+- [Actual release evidence](release-verification.md)

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,5 +1,12 @@
 # Release verification
 
+Current planning context (2026-09-05): the [framework roadmap](roadmap.md) is the
+forward delivery sequence. Historical evidence below remains scoped to its stated
+revision and environment. References to missing Linear mappings in the enrollment
+candidate describe that earlier run; the planning branch now has a configured
+sandbox connection and backlog tickets. New plans/specifications do not establish
+runtime capability, live qualification, or release readiness.
+
 This checkout is an implementation candidate, not a published or certified cross-platform release. Native Apple silicon source bootstrap from both the development worktree and a disposable clean clone, repeated setup, language fixtures, lint/type checks, strict OpenSpec validation, a hash-constrained isolated wheel installation, the final integrated required checks, and independent source review have passed. Pull request #1's expanded matrix passed on Ubuntu 24.04 and 26.04 for x64 and ARM64 plus macOS Intel. Each job published a distinct clean receipt for the same synthetic merge revision with all five required checks passing.
 
 Outstanding: factory-clean Apple silicon setup; actual Codex Cloud and Claude Cloud hosted lifecycles; live client hook sessions; full live provider mutation conformance; behavioral skill evaluations; publication of verified release artifacts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,106 @@
+# AI-DLC roadmap
+
+Updated: 2026-09-05. Linear owns priority and status. This document owns the
+delivery sequence; [product direction](product-direction.md) owns the intended
+outcomes. The capabilities below are planned, not shipped.
+
+## Direction and current baseline
+
+AI-DLC prepares portable environments and connects replaceable tools, guidance,
+artifacts, and quality workflows. The harness performs development using native
+tools or AI-DLC services as appropriate. UI/UX is an optional workflow, not the
+framework's organizing purpose.
+
+The current Python implementation supplies bootstrap/enrollment, scoped
+configuration, provider adapters, managed assets, work records, and finish gates.
+The next work connects those foundations and improves product-to-delivery
+guidance. See [current architecture](architecture.md) and
+[planned contracts](design/framework-delivery.md) for the distinction.
+
+## Dependency-ordered delivery
+
+Each row is an independently reviewed ticket with an execution plan. Plan tasks
+are steps inside that ticket, not additional disconnected issues. All ten items
+were published to the Sandbox-aidlc team; SAN-6 and SAN-7 were revised in place.
+
+| Ticket | Outcome | Must follow | Execution plan |
+| --- | --- | --- | --- |
+| [SAN-9](https://linear.app/sandbox-aidlc/issue/SAN-9/connect-provider-roles-to-tool-installation-and-harness-guidance) | M1: Connect provider roles to tool installation and harness guidance | Planning integrated | [component-capability-contract](superpowers/plans/2026-09-05-component-capability-contract.md) |
+| [SAN-10](https://linear.app/sandbox-aidlc/issue/SAN-10/make-selected-project-tools-and-guidance-ready-across-machines) | M1: Make selected project tools and guidance ready across machines | SAN-9 | [connected-project-readiness](superpowers/plans/2026-09-05-connected-project-readiness.md) |
+| [SAN-11](https://linear.app/sandbox-aidlc/issue/SAN-11/discover-and-safely-configure-a-projects-linear-connection) | M1: Discover and safely configure a project's Linear connection | SAN-9 | [linear-provider-onboarding](superpowers/plans/2026-09-05-linear-provider-onboarding.md) |
+| [SAN-12](https://linear.app/sandbox-aidlc/issue/SAN-12/import-pinned-workflow-guidance-and-expose-it-to-supported-harnesses) | M1: Import pinned workflow guidance and expose it to supported harnesses | SAN-9, SAN-10 | [portable-workflow-bundles](superpowers/plans/2026-09-05-portable-workflow-bundles.md) |
+| [SAN-13](https://linear.app/sandbox-aidlc/issue/SAN-13/guide-product-discovery-and-feature-selection-for-new-and-existing) | M2: Guide product discovery and feature selection for new and existing products | Planning integrated | [product-shaping-workflow](superpowers/plans/2026-09-05-product-shaping-workflow.md) |
+| [SAN-14](https://linear.app/sandbox-aidlc/issue/SAN-14/carry-product-requirements-into-independently-deliverable) | M2: Carry product requirements into independently deliverable specifications and tickets | SAN-13 | [spec-delivery-traceability](superpowers/plans/2026-09-05-spec-delivery-traceability.md) |
+| [SAN-6](https://linear.app/sandbox-aidlc/issue/SAN-6/add-optional-uiux-design-generation-and-evaluation-workflow) | M2: Add optional UI/UX design generation and evaluation workflow | SAN-13, SAN-14 | [design-pm-workflow](superpowers/plans/2026-09-05-design-pm-workflow.md) |
+| [SAN-15](https://linear.app/sandbox-aidlc/issue/SAN-15/qualify-portable-setup-provider-replacement-and-development-handoffs) | M3: Qualify portable setup, provider replacement, and development handoffs | SAN-10, SAN-11, SAN-12, SAN-14 | [framework-qualification](superpowers/plans/2026-09-05-framework-qualification.md) |
+| [SAN-16](https://linear.app/sandbox-aidlc/issue/SAN-16/evaluate-product-shaping-and-delivery-guidance-against-baseline) | M3: Evaluate product shaping and delivery guidance against baseline behavior | SAN-13, SAN-14 | [workflow-quality-calibration](superpowers/plans/2026-09-05-workflow-quality-calibration.md) |
+| [SAN-7](https://linear.app/sandbox-aidlc/issue/SAN-7/calibrate-uiux-evaluation-and-measure-its-incremental-value) | M3: Calibrate UI/UX evaluation and measure its incremental value | SAN-6 | [design-pm-calibration](superpowers/plans/2026-09-05-design-pm-calibration.md) |
+
+### M1: Connected setup and replaceable guidance
+
+A selected provider connects to its tools, local configuration requirements,
+instructions, and honest readiness checks. Linear setup no longer requires
+manually copying UUIDs. Reviewed Markdown workflows can be pinned and distributed
+without creating an arbitrary-code package system.
+
+### M2: Product decisions become deliverable work
+
+Greenfield and brownfield examples guide evidence gathering, alternatives,
+feature selection, scope, and success criteria. Product requirement IDs flow
+into behavioral specifications and independently deliverable tickets. UI work
+can add a brief, rubric, generation, independent evaluation, and bounded revision.
+
+### M3: Prove portability and quality
+
+Observe real setup and continuation on the named native/container targets, test
+replacement of a tracker in isolated destinations, and measure product/design
+guidance against baselines. Missing human ratings, experiment budgets, or live
+environments leave the affected evidence pending; they do not block unrelated
+preparation or become invented results.
+
+## Start and completion rules
+
+Default first implementation: [SAN-9](https://linear.app/sandbox-aidlc/issue/SAN-9/connect-provider-roles-to-tool-installation-and-harness-guidance).
+[SAN-13](https://linear.app/sandbox-aidlc/issue/SAN-13/guide-product-discovery-and-feature-selection-for-new-and-existing)
+is independently ready for a product-guidance owner. Integrate this planning
+branch before starting feature branches. Milestone labels do not serialize
+otherwise independent work.
+
+Seven behavior tickets have separate OpenSpec changes; the three M3 tickets
+verify predecessor behavior and do not invent new specifications. Each plan
+lists files, interfaces, acceptance, refusal cases, tests, exclusions, and
+handoff requirements. Implement and finish one selected ticket at a time.
+
+Dependencies are recorded as native Linear blocking relationships and in the
+[machine-readable delivery index](planning/delivery-index.json). The current
+Work schema does not yet support dependency fields: check the graph manually
+until SAN-14 implements that behavior.
+
+The [master plan](superpowers/plans/2026-09-05-framework-delivery.md) defines
+milestone exits. The [executor handoff](handoffs/framework-delivery.md) is the
+starting document for an agent without this conversation.
+[SAN-8: planning delivery](https://linear.app/sandbox-aidlc/issue/SAN-8/document-and-sequence-the-portable-framework-delivery-roadmap)
+tracks documentation/review only; its completion must not close these features.
+
+## Retained v4 release obligations
+
+The implementation PR is merged, but
+[portable-development-v4](../openspec/changes/portable-development-v4/tasks.md)
+remains active with four unfinished release tasks. Do not create replacement
+claims or archive it merely because this roadmap exists.
+
+- Clean-machine, container, and hosted-client walkthroughs.
+- Full live provider mutation conformance under enforced isolation.
+- Behavioral evaluations already declared in `agents/evaluation.toml`.
+- Verified release artifacts and release bootstrap manifest.
+
+[Release verification](release-verification.md) records actual evidence. M3
+evidence can satisfy an existing gate only when its scope matches. New product
+and UI comparisons do not consume or redefine existing evaluation budgets.
+
+## Explicitly deferred
+
+Additional harness/hosted adapters, executable workflow packages, knowledge
+onboarding, automatic Linear Project assignment, existing-work attachment, and
+release publication need separately scoped work. They are not hidden acceptance
+requirements for these ten tickets.

--- a/docs/superpowers/plans/2026-09-05-component-capability-contract.md
+++ b/docs/superpowers/plans/2026-09-05-component-capability-contract.md
@@ -1,0 +1,128 @@
+# Connect provider roles to tool installation and harness guidance Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.
+
+**Architecture:** Component schema 1 contains id, roles, modules, guidance, required_config. Modules name existing entries in modules/catalog.toml; guidance is a list of repository/package-relative Markdown paths. Built-ins are indexed by provider kind. An optional providers.<id>.component overrides the component ID. Optional providers.<id>.component_manifest and component_manifest_sha256 select a checked-in JSON manifest verified before parsing. Unknown fields, duplicate IDs, unsafe paths, missing hashes, unknown modules, and incompatible roles fail validation. No manifest command strings or installers are executed. Native adapters remain in the existing provider registry.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [component-capability-contract](../../../openspec/changes/component-capability-contract/specs/component-capability-contract/spec.md)
+
+## Global constraints
+
+No package registry, remote downloads, new provider operations, model selection, or changes to finish gates.
+
+Milestone: M1. Dependencies: none; ready after the planning branch is integrated.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+resolve_components(config: dict, catalog: dict) -> dict returns {schema: 1, components: [{id, provider, role, modules, guidance, required_config}], unresolved: [{provider, role, reason}]}. Lists are sorted by stable IDs. This function is pure and accepts only explicitly selected roles; the caller excludes compatibility-only base defaults.
+
+### Files and ownership
+
+- Create src/ai_dlc/components.py
+- Create modules/components.json
+- Create agents/providers/openspec.md, agents/providers/linear.md, agents/providers/github-issues.md
+- Test packaged assets in tests/test_templates.py
+- Modify src/ai_dlc/config.py
+- Test tests/test_components.py
+- Modify tests/test_config.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## First executable acceptance example
+
+The following is a target regression, to be added during implementation. It is not run in this documentation change.
+
+```python
+from ai_dlc.components import resolve_components
+
+def test_selected_spec_requires_its_tool():
+    catalog = {"schema": 1, "components": [{"id": "openspec", "roles": ["specs"], "modules": ["openspec"], "guidance": ["guidance/openspec.md"], "required_config": []}]}
+    result = resolve_components({"roles": {"specs": "openspec"}}, catalog)
+    assert result["components"][0]["modules"] == ["openspec"]
+    assert result["unresolved"] == []
+```
+
+Run it first and verify the failure is the missing specified behavior, then implement against the interfaces above.
+
+Tests are introduced incrementally: Task 1 covers only its delivered boundary;
+add later-task assertions when that task begins. Capture red then green within
+each task. Do not commit a deliberately failing suite or make future behavior
+pass with placeholders. The first acceptance example may span multiple tasks;
+add it at the task that owns its complete interface.
+
+### Task 1: Validated component catalog
+
+**Files:** src/ai_dlc/components.py, modules/components.json, agents/providers/*.md, tests/test_components.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Implement catalog loading/validation with schema-1 fixtures for openspec, linear, github-issues and two synthetic providers. Reject missing modules, duplicate IDs, digest mismatches and unsafe paths; ship referenced built-in guidance. Keep role resolution for Task 2 and provider configuration integration for Task 3.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 1.3 Implement catalog loading/validation with schema-1 fixtures for openspec, linear, github-issues and two synthetic providers. Reject missing modules, duplicate IDs, digest mismatches and unsafe paths; ship referenced built-in guidance. Keep role resolution for Task 2 and provider configuration integration for Task 3.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_components.py tests/test_config.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Pure resolution
+
+**Files:** src/ai_dlc/components.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Implement catalog validation and resolve_components; keep installation, network, writes, and provider operations outside the resolver. Preserve unresolved-provider diagnostics.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 2.3 Implement catalog validation and resolve_components; keep installation, network, writes, and provider operations outside the resolver. Preserve unresolved-provider diagnostics.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_components.py tests/test_config.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Configuration integration
+
+**Files:** src/ai_dlc/config.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Validate the three optional provider metadata fields and machine-layer refusal; document a complete third-party manifest example and verify packaged component data.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 3.3 Validate the three optional provider metadata fields and machine-layer refusal; document a complete third-party manifest example and verify packaged component data.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_components.py tests/test_config.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| CC-01: Deterministic capability resolution | 1, 2 | Focused positive and refusal cases, then integration and required project checks. |
+| CC-02: Verified extension metadata | 1, 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+| CC-03: Compatibility and provenance | 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate component-capability-contract --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish component-capability-contract` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-connected-project-readiness.md
+++ b/docs/superpowers/plans/2026-09-05-connected-project-readiness.md
@@ -1,0 +1,131 @@
+# Make selected project tools and guidance ready across machines Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.
+
+**Architecture:** Add ai-dlc project readiness --root PATH (read-only; exit 0 only when required checks are ready, else 1). Dimensions are tool, configuration, credential, guidance, and provider-health. Use catalog verify commands through a bounded injected probe; no installs/network for plain readiness, provider-health remains unverified unless existing explicit health inspection was requested through doctor. Provider-health is informational in offline readiness. Extend setup plan/apply and machine plan/apply with optional --root; root-aware planning unions declared modules with resolved component modules without editing the profile. Apply follows the existing explicit mutation command. Guidance readiness checks that the selected harness receives an index pointing to real configured-provider instructions. Existing root/machine doctor readiness contract is preserved, with the richer project report added under project_readiness.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [connected-project-readiness](../../../openspec/changes/connected-project-readiness/specs/connected-project-readiness/spec.md)
+
+## Global constraints
+
+No credential auto-loading, automatic account choice, new client support claim, hosted control plane, or weakening of existing doctor/finish behavior.
+
+Milestone: M1. Dependencies: `component-capability-contract`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+inspect_readiness(root: Path, config: dict, *, environ: Mapping[str,str], probe: Callable[[list[str]],dict]) -> dict returns {schema:1, ready:bool, checks:[{component, dimension, status, reason, next_action}], qualification:'not-assessed'}. status is ready, missing, blocked, or unverified. Extend MachineManager.plan/apply with optional root: Path | None = None; omitted root retains current behavior.
+
+### Files and ownership
+
+- Create src/ai_dlc/readiness.py
+- Modify src/ai_dlc/cli.py
+- Modify src/ai_dlc/machine.py
+- Modify src/ai_dlc/provision.py
+- Modify src/ai_dlc/agents.py
+- Test tests/test_readiness.py
+- Modify tests/test_machine.py, tests/test_cli.py, tests/test_rendering.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## First executable acceptance example
+
+The following is a target regression, to be added during implementation. It is not run in this documentation change.
+
+```python
+from pathlib import Path
+from ai_dlc.readiness import inspect_readiness
+
+def test_missing_tool_reports_next_action(tmp_path: Path):
+    result = inspect_readiness(tmp_path, {"roles": {"specs": "openspec"}}, environ={}, probe=lambda argv: {"available": False})
+    gaps = [c for c in result["checks"] if c["dimension"] == "tool"]
+    assert gaps and gaps[0]["status"] == "missing"
+    assert gaps[0]["next_action"]
+    assert result["ready"] is False
+    assert result["qualification"] == "not-assessed"
+```
+
+Run it first and verify the failure is the missing specified behavior, then implement against the interfaces above.
+
+Tests are introduced incrementally: Task 1 covers only its delivered boundary;
+add later-task assertions when that task begins. Capture red then green within
+each task. Do not commit a deliberately failing suite or make future behavior
+pass with placeholders. The first acceptance example may span multiple tasks;
+add it at the task that owns its complete interface.
+
+### Task 1: Readiness model
+
+**Files:** src/ai_dlc/readiness.py, tests/test_readiness.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Implement inspect_readiness with injected probes and tests for absent binary, absent guidance, absent environment key, valid offline requirements, and headless capability. Prove outputs never contain credential values. Keep provisioning and CLI exposure for Tasks 2 and 3.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 1.3 Implement inspect_readiness with injected probes and tests for absent binary, absent guidance, absent environment key, valid offline requirements, and headless capability. Prove outputs never contain credential values. Keep provisioning and CLI exposure for Tasks 2 and 3.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_readiness.py tests/test_machine.py tests/test_provision.py tests/test_cli.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Root-aware setup
+
+**Files:** src/ai_dlc/machine.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Forward optional root through public commands, manager, and provisioning; union modules using CC-01 and preserve explicit profile/machine precedence and no-root behavior.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 2.3 Forward optional root through public commands, manager, and provisioning; union modules using CC-01 and preserve explicit profile/machine precedence and no-root behavior.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_readiness.py tests/test_machine.py tests/test_provision.py tests/test_cli.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Harness guidance and reporting
+
+**Files:** src/ai_dlc/agents.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Render an owned provider/tool index into supported client guidance; implement project readiness and add diagnostics to doctor without overriding machine enrollment failures.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 3.3 Render an owned provider/tool index into supported client guidance; implement project readiness and add diagnostics to doctor without overriding machine enrollment failures.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_readiness.py tests/test_machine.py tests/test_provision.py tests/test_cli.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| RD-01: Connected provisioning plan | 1, 2 | Focused positive and refusal cases, then integration and required project checks. |
+| RD-02: Readiness is actionable and scoped | 1, 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+| RD-03: Environment consistency preserves local identity | 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate connected-project-readiness --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish connected-project-readiness` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-design-pm-calibration.md
+++ b/docs/superpowers/plans/2026-09-05-design-pm-calibration.md
@@ -1,0 +1,109 @@
+# Calibrate UI/UX evaluation and measure its incremental value Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Measure when the optional design evaluator improves UI outcomes enough to justify its cost.
+
+**Architecture:** Use original cases covering polished-but-broken, plain-but-usable, established-brand, keyboard failure, and screenshot-only candidates. Calibration and held-out assignments are frozen before tuning. A human supplies taste anchors and ratings. Declare a separate model/run budget before paid execution. Positive aesthetic scores cannot compensate for failed required journeys or absent evidence. Recommend retaining, simplifying, or removing the evaluator based on observed results.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** No new formal behavior: this ticket verifies its predecessor contracts.
+
+## Global constraints
+
+No paid runs without a declared budget, fabricated human preference, broad client qualification, or claim that distribution tests prove design quality.
+
+Milestone: M3. Dependencies: `design-pm-workflow`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+Consume candidate/rubric/report identity from design-pm-workflow. Compare baseline, rubric-only, and rubric-plus-independent-evaluation conditions. Preserve human labels, pairwise judgments, defect findings, time and usage, and held-out case identity.
+
+### Files and ownership
+
+- Create agents/evaluations/design-pm/protocol.md
+- Create agents/evaluations/design-pm/cases.json
+- Create docs/verification/design-pm-evaluation.md
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## Behavioral review cases
+
+For each criterion below, preserve the input, produced artifact or observation, expected result, actual result, and evidence. Packaging checks only prove asset delivery; they do not substitute for these cases.
+
+- **DE-01 — Separate calibration evidence:** Original examples include behavioral defects and subjective disagreement; held-out cases are not used to tune the evaluator.
+- **DE-02 — Incremental value comparison:** Matched baseline, rubric-only, and independent-evaluation runs report human preference, missed defects, false positives, cost, and time.
+- **DE-03 — Honest completion:** Missing budget, human review, or browser access is reported; unavailable evidence does not qualify the workflow as improving design.
+
+### Task 1: Prepare cases and human anchors
+
+**Files:** agents/evaluations/design-pm/cases.json plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Create the original UI cases, identify known defects, and collect human score rationales without substituting model-written labels.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 1.3 Create the original UI cases, identify known defects, and collect human score rationales without substituting model-written labels.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Freeze comparison protocol
+
+**Files:** agents/evaluations/design-pm/protocol.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Declare the three conditions, repeated runs, versions, budget, evidence handling, and held-out split.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 2.3 Declare the three conditions, repeated runs, versions, budget, evidence handling, and held-out split.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Evaluate and report
+
+**Files:** docs/verification/design-pm-evaluation.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Run authorized experiments, compare candidate evidence and human judgments, and recommend the smallest effective workflow.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 3.3 Run authorized experiments, compare candidate evidence and human judgments, and recommend the smallest effective workflow.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| DE-01: Separate calibration evidence | 1, 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DE-02: Incremental value comparison | 1, 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DE-03: Honest completion | 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish design-pm-calibration` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-design-pm-workflow.md
+++ b/docs/superpowers/plans/2026-09-05-design-pm-workflow.md
@@ -1,0 +1,117 @@
+# Add optional UI/UX design generation and evaluation workflow Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Implement the existing Design PM proposal as an optional UI/UX workflow consuming a shaped product outcome and delivering evidence for its interaction criteria.
+
+**Architecture:** Retain the current OpenSpec Design PM requirements. Implement two skills: design-brief creates the rubric and hands generation to the chosen existing visual tool/skill; design-evaluate inspects a running candidate or records static limitations. No new image generator or universal orchestrator. First sample defaults remain 0–4 scores, minimum 3 on required rated criteria, all required behavior checks pass, initial candidate plus at most two revision rounds; these are examples to review per task, not global gates. Existing design systems take precedence over novelty. A small UI fix may use one concise report.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [design-pm-workflow](../../../openspec/changes/design-pm-workflow/specs/design-pm/spec.md)
+
+## Global constraints
+
+No AI-DLC frontend, universal design score, mandatory evaluator for every task, inferred human review, or new completion gate.
+
+Milestone: M2. Dependencies: `product-shaping-workflow`, `spec-delivery-traceability`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+Input is a PS product brief and TR delivery slice with RQ IDs. Output is the existing docs/design/<work-id>/ brief/rubric/iterations/decision artifact contract. Criterion IDs are local to a versioned rubric and reference relevant RQ IDs. Findings reference candidate revision, criterion, observed state, evidence, severity, and next action.
+
+### Files and ownership
+
+- Create agents/skills/design-brief/SKILL.md
+- Create agents/skills/design-evaluate/SKILL.md
+- Create agents/templates/design-rubric.md, design-evaluation.md and design-selection.md
+- Create agents/examples/design-evaluation/
+- Update agents/skills.lock.json and generated copies
+- Modify docs/workflows/design-to-implementation.md and matching project templates
+- Test tests/test_templates.py, tests/test_rendering.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## Behavioral review cases
+
+For each criterion below, preserve the input, produced artifact or observation, expected result, actual result, and evidence. Packaging checks only prove asset delivery; they do not substitute for these cases.
+
+- **UI-01 — Candidate contract:** A static candidate leaves interaction checks unverified; a failed required journey blocks acceptance regardless of aesthetics.
+- **UI-02 — Proportional effort:** A small brand-constrained fix uses existing components and a concise report without inventing a new visual direction.
+- **UI-03 — Revision selection:** A regressed later candidate can be rejected in favor of the earlier candidate with matching evidence.
+
+### Task 1: Rubric and evaluator examples
+
+**Files:** agents/examples/design-evaluation/ plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Use the shaped product brief; add criterion-specific score anchors and examples of attractive-but-broken, brand-consistent, and unverified static outputs.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 1.3 Use the shaped product brief; add criterion-specific score anchors and examples of attractive-but-broken, brand-consistent, and unverified static outputs.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Portable skills and artifact handoff
+
+**Files:** agents/skills/design-evaluate/SKILL.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Implement design-brief/design-evaluate with independent-session or human fallback, reproducible findings, revision/plateau rules, and earlier-candidate selection.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 2.3 Implement design-brief/design-evaluate with independent-session or human fallback, reproducible findings, revision/plateau rules, and earlier-candidate selection.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Integration and packaging
+
+**Files:** tests/test_templates.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Connect the optional route from product shaping, ship templates/examples, verify owned updates and clearly leave live quality improvement pending.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 3.3 Connect the optional route from product shaping, ship templates/examples, verify owned updates and clearly leave live quality improvement pending.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| DP-01: Design intent precedes evaluation | 1, 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DP-02: Evaluation preserves evidence and uncertainty | 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DP-03: Independent review is explicit | 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DP-04: Iteration respects budgets and candidate identity | 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DP-05: Guidance travels through existing project distribution | 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| DP-06: Calibration claims require measured evidence | 1, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate design-pm-workflow --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish design-pm-workflow` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-framework-delivery.md
+++ b/docs/superpowers/plans/2026-09-05-framework-delivery.md
@@ -1,0 +1,83 @@
+# Framework Delivery Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans with one ticket's linked plan at a time. Use superpowers:subagent-driven-development only when delegation is authorized. Checkboxes record delivered work, not planning completion.
+
+**Goal:** Deliver the approved portable development framework with connected setup, replaceable tools, product-to-delivery guidance, and measured qualification.
+
+**Architecture:** Retain current Python services and native tools. Add a small component/readiness boundary, strengthen product/spec handoffs, and distribute optional workflows through managed assets. Each behavior ticket owns a separate OpenSpec change.
+
+**Tech Stack:** Python 3.12, uv/mise/native package managers, OpenSpec, Markdown, current provider adapters, and Codex/Claude managed assets.
+
+**Spec:** [Product direction](../../product-direction.md), [delivery architecture](../../design/framework-delivery.md), and each ticket's formal change below.
+
+## Global constraints
+
+- Existing schema 4, profile ownership, credential isolation, authored-content preservation, and completion gates remain intact.
+- No runtime implementation is delivered by this planning branch.
+- Native macOS arm64 and Ubuntu 24.04 arm64 devcontainer are the initial qualification targets; client/hosted claims require actual evidence.
+- UI/UX is optional within product development. Specification is observable behavior; ticket is a deliverable slice; task is a smaller implementation step.
+- Paid experiments require a separately declared budget, and human ratings require humans.
+- Integrate the planning branch before feature work. Run source bootstrap and required project checks as described in AGENTS.md.
+- Use one reviewed branch per ticket, with independently finishable specifications. Do not implement dependency APIs by guessing.
+- Future Work.depends_on/requirements fields are introduced only by the traceability ticket; until then use this graph and native tracker relations.
+
+## Ticket order and plans
+
+| Work ID | Milestone | Prerequisites | Plan |
+| --- | --- | --- | --- |
+| `component-capability-contract` | M1 | None | [Execute](2026-09-05-component-capability-contract.md) |
+| `connected-project-readiness` | M1 | component-capability-contract | [Execute](2026-09-05-connected-project-readiness.md) |
+| `linear-provider-onboarding` | M1 | component-capability-contract | [Execute](2026-09-05-linear-provider-onboarding.md) |
+| `portable-workflow-bundles` | M1 | component-capability-contract, connected-project-readiness | [Execute](2026-09-05-portable-workflow-bundles.md) |
+| `product-shaping-workflow` | M2 | None | [Execute](2026-09-05-product-shaping-workflow.md) |
+| `spec-delivery-traceability` | M2 | product-shaping-workflow | [Execute](2026-09-05-spec-delivery-traceability.md) |
+| `design-pm-workflow` | M2 | product-shaping-workflow, spec-delivery-traceability | [Execute](2026-09-05-design-pm-workflow.md) |
+| `framework-qualification` | M3 | connected-project-readiness, linear-provider-onboarding, portable-workflow-bundles, spec-delivery-traceability | [Execute](2026-09-05-framework-qualification.md) |
+| `workflow-quality-calibration` | M3 | product-shaping-workflow, spec-delivery-traceability | [Execute](2026-09-05-workflow-quality-calibration.md) |
+| `design-pm-calibration` | M3 | design-pm-workflow | [Execute](2026-09-05-design-pm-calibration.md) |
+
+Default first implementation: component-capability-contract.
+Product-shaping-workflow is independently ready for a guidance-focused owner.
+M1 and M2 are outcomes, not a requirement to serialize independent work.
+
+## Milestone exit criteria
+
+### M1: Connected setup and replaceable guidance
+
+- [ ] Explicit role selection resolves tool modules, configuration requirements, and provider guidance.
+- [ ] Root-aware setup can prepare the selected tools; offline readiness names concrete gaps without false qualification claims.
+- [ ] Linear discovery and local configuration need no manual UUID hunting or secret persistence.
+- [ ] A pinned external Markdown workflow bundle is usable offline from a fresh checkout and respects owned-content updates.
+
+### M2: Product-to-delivery workflow
+
+- [ ] Worked greenfield and brownfield examples produce evidence-based outcomes, scope, requirement IDs, and proceed/investigate/stop decisions.
+- [ ] Behavioral specifications, deliverable tickets, dependencies, and verification have explicit links.
+- [ ] A changed interface can opt into the UI/UX workflow while non-UI work retains appropriate verification.
+- [ ] A small change can use a small artifact set without bypassing applicable project gates.
+
+### M3: Observed qualification and workflow quality
+
+- [ ] Both initial live environments demonstrate repeat setup and continued work with equivalent portable choices.
+- [ ] Disposable Linear/GitHub Issues cycles demonstrate provider substitution and stable previous bindings.
+- [ ] Human-grounded product/delivery and UI evaluations report actual results, disagreement, cost, and limitations.
+- [ ] Existing v4 release gates are updated only with matching evidence; no test category substitutes for another.
+
+## Per-ticket execution sequence
+
+1. Read the work record, linked plan, complete OpenSpec change when required, and predecessor interfaces.
+2. Check actual dependency tracker state/evidence; choose a ready ticket.
+3. Link `codex/<work-id>` with `ai-dlc work link <work-id> branch codex/<work-id>`, then run `ai-dlc work start <work-id>`. Do not execute another ticket's scope.
+4. Follow the plan's focused regression → implementation → verification → commit steps.
+5. Review against exclusions and requirement coverage, then run required checks.
+6. For behavior tickets, validate and archive the completed OpenSpec change and update its work reference.
+7. Link reviewed PR and merged-revision evidence; finish through the existing service.
+8. Use the [handoff checklist](../../handoffs/framework-delivery.md) for continuation.
+
+## Review of this planning delivery
+
+The planning ticket covers documents, specs, plans, source/generated handbook consistency,
+and synchronized backlog metadata. It must not close implementation tickets.
+Validation for this branch includes all seven active new capability changes, local
+link/reference checks, work-record parsing, dependency-cycle checks, and the required
+project suite. The original v4 change remains active with its unmet release tasks.

--- a/docs/superpowers/plans/2026-09-05-framework-qualification.md
+++ b/docs/superpowers/plans/2026-09-05-framework-qualification.md
@@ -1,0 +1,110 @@
+# Qualify portable setup, provider replacement, and development handoffs Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Produce reproducible evidence that the delivered framework works on the initial supported environments and supports one safe provider substitution.
+
+**Architecture:** Initial live qualification targets are a clean native macOS arm64 environment and clean Ubuntu 24.04 arm64 devcontainer; hosted clients and new harness adapters remain separate unqualified targets. If a target is inaccessible, record unavailable and leave the corresponding acceptance unmet. Use a disposable project and separately scoped credentials. Demonstrate provider-neutral tracker behavior using Linear and the already implemented GitHub Issues adapter on designated sandbox destinations, including absence of in_progress on GitHub Issues. Never change this project's tracker to perform the experiment. Test same-revision repeat setup, offline guidance, authored-file preservation, resumed work, and a staged update failure. All live writes require explicit disposable destinations in the run configuration.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** No new formal behavior: this ticket verifies its predecessor contracts.
+
+## Global constraints
+
+No production tracker changes, invented clean-machine evidence, new platform support, package publication, or automatic closure when an environment is unavailable.
+
+Milestone: M3. Dependencies: `connected-project-readiness`, `linear-provider-onboarding`, `portable-workflow-bundles`, `spec-delivery-traceability`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+Report fields: commit, profile_revision, bundle_revisions, environment, harness_version, scenario_id, steps, expected, observed, evidence, result, limitations. result is passed/failed/unavailable/not-run. Evidence is fixture, live-local, live-container, or live-hosted and is never promoted between categories.
+
+### Files and ownership
+
+- Create docs/verification/framework-qualification.md
+- Create scripts/qualify_framework.py
+- Create tests/test_qualification_report.py
+- Update docs/release-verification.md
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## Behavioral review cases
+
+For each criterion below, preserve the input, produced artifact or observation, expected result, actual result, and evidence. Packaging checks only prove asset delivery; they do not substitute for these cases.
+
+- **Q-01 — Setup continuity:** Demonstrate equivalent portable requirements on both initial targets with independent local bindings and a repeat setup that creates no duplicate owned assets.
+- **Q-02 — Provider substitution:** Demonstrate a new work cycle using each tracker adapter without changing workflow rationale; existing records stay bound, and unsupported transitions are explicit.
+- **Q-03 — Handoff and honest evidence:** A fresh session completes the next action from project artifacts alone; report tool/client limits and preserve transcripts and receipts for each actual target.
+
+### Task 1: Prepare repeatable protocol
+
+**Files:** scripts/qualify_framework.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Write exact environment bootstrap commands, disposable source/target checks, result schema, evidence paths, and cleanup instructions; validate report classification without live writes.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 1.3 Write exact environment bootstrap commands, disposable source/target checks, result schema, evidence paths, and cleanup instructions; validate report classification without live writes.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_qualification_report.py tests/test_machine_integration.py tests/test_rebind.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Run supported target walkthroughs
+
+**Files:** docs/verification/framework-qualification.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Execute the same scenario from clean native and container environments, repeat setup, simulate restart and unavailable source, and retain evidence per target.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 2.3 Execute the same scenario from clean native and container environments, repeat setup, simulate restart and unavailable source, and retain evidence per target.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_qualification_report.py tests/test_machine_integration.py tests/test_rebind.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Prove replacement and handoff
+
+**Files:** docs/release-verification.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Use two scoped sandbox tracker destinations and a fresh-session handoff; record actual behavior, gate failures, unsupported transitions, and remaining release gaps.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 3.3 Use two scoped sandbox tracker destinations and a fresh-session handoff; record actual behavior, gate failures, unsupported transitions, and remaining release gaps.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_qualification_report.py tests/test_machine_integration.py tests/test_rebind.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| Q-01: Setup continuity | 1, 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| Q-02: Provider substitution | 1, 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| Q-03: Handoff and honest evidence | 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish framework-qualification` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md
+++ b/docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md
@@ -1,0 +1,126 @@
+# Discover and safely configure a project's Linear connection Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.
+
+**Architecture:** Add ai-dlc provider connect PROVIDER --root PATH. Without selection flags it prints complete discovery and exits without writes. Preview flags are --organization UUID --team UUID --in-progress UUID --closed UUID; --apply additionally writes local shared non-secret mappings. Use existing token_env; do not create or rotate keys. Validate selected team belongs to the selected organization result, started/completed state types and team membership. Multiple states are always listed; never infer In Progress from first started state. Paginate all selected discovery collections or fail incomplete. Preserve unrelated TOML content using a reviewed TOML editing approach; tests must assert comments and unrelated values survive. Refuse changed existing mappings when local work is already bound; point to explicit rebind. Preview can save its non-secret plan with --plan-file PATH under .ai-dlc/local. Apply consumes --plan-file PATH with --apply, revalidates selections against fresh discovery, and checks before_digest immediately before the atomic write; it never silently recomputes a different approved plan.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [linear-provider-onboarding](../../../openspec/changes/linear-provider-onboarding/specs/linear-provider-onboarding/spec.md)
+
+## Global constraints
+
+No API-key creation, Linear Project creation, issue mutation, organization switching, or automatic rebind. Use existing sandbox only for authorized live reads.
+
+Milestone: M1. Dependencies: `component-capability-contract`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+discover_linear(settings: dict, *, environ: Mapping[str,str], client) -> dict returns {organization:{id,name,urlKey}, teams:[{id,name,key,states:[{id,name,type}]}]}. plan_linear_connection(config:dict, discovery:dict, selection:dict) -> dict returns {provider, before_digest, selected, patch}; selection requires organization_id, team_id, in_progress, closed. apply_linear_connection(path:Path, plan:dict) verifies the before digest and atomically replaces only selected provider settings.
+
+### Files and ownership
+
+- Create src/ai_dlc/provider_onboarding.py
+- Modify src/ai_dlc/providers/linear.py
+- Modify src/ai_dlc/cli.py
+- Test tests/test_provider_onboarding.py
+- Modify tests/test_cli.py, tests/test_rebind.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## First executable acceptance example
+
+The following is a target regression, to be added during implementation. It is not run in this documentation change.
+
+```python
+import pytest
+from ai_dlc.provider_onboarding import plan_linear_connection
+
+def test_state_from_another_team_is_rejected():
+    discovery = {"organization": {"id": "org"}, "teams": [{"id": "team", "states": [{"id": "done", "type": "completed"}]}]}
+    with pytest.raises(ValueError):
+        plan_linear_connection({"providers": {"linear": {}}}, discovery, {"organization_id": "org", "team_id": "team", "in_progress": "foreign", "closed": "done"})
+```
+
+Run it first and verify the failure is the missing specified behavior, then implement against the interfaces above.
+
+Tests are introduced incrementally: Task 1 covers only its delivered boundary;
+add later-task assertions when that task begins. Capture red then green within
+each task. Do not commit a deliberately failing suite or make future behavior
+pass with placeholders. The first acceptance example may span multiple tasks;
+add it at the task that owns its complete interface.
+
+### Task 1: Paginated discovery
+
+**Files:** src/ai_dlc/provider_onboarding.py, tests/test_provider_onboarding.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Implement discover_linear with injected httpx responses covering multiple teams, duplicate names, two started states, pagination, authorization failure, and incomplete result refusal. Expose no mutations or CLI apply in this task.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 1.3 Implement discover_linear with injected httpx responses covering multiple teams, duplicate names, two started states, pagination, authorization failure, and incomplete result refusal. Expose no mutations or CLI apply in this task.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_provider_onboarding.py tests/test_cli.py tests/test_rebind.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Selection and guarded local write
+
+**Files:** src/ai_dlc/provider_onboarding.py, tests/test_provider_onboarding.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Implement plan_linear_connection and apply_linear_connection: validate selection membership/types and config digest, preserve comments and unrelated sections, write atomically, and prove invalid/stale selections write nothing. Task 3 owns CLI wiring and fresh remote membership checks.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 2.3 Implement plan_linear_connection and apply_linear_connection: validate selection membership/types and config digest, preserve comments and unrelated sections, write atomically, and prove invalid/stale selections write nothing. Task 3 owns CLI wiring and fresh remote membership checks.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_provider_onboarding.py tests/test_cli.py tests/test_rebind.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: CLI and guarded apply
+
+**Files:** src/ai_dlc/cli.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Implement provider connect preview/apply, credential-redacted errors, and binding-drift refusal. Add a sandbox read-only walkthrough procedure.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 3.3 Implement provider connect preview/apply, credential-redacted errors, and binding-drift refusal. Add a sandbox read-only walkthrough procedure.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_provider_onboarding.py tests/test_cli.py tests/test_rebind.py tests/test_providers.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| LN-01: Complete scoped discovery | 1, 2 | Focused positive and refusal cases, then integration and required project checks. |
+| LN-02: Validated local preview and apply | 1, 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+| LN-03: Existing work and credentials stay stable | 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate linear-provider-onboarding --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish linear-provider-onboarding` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md
+++ b/docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md
@@ -1,0 +1,127 @@
+# Import pinned workflow guidance and expose it to supported harnesses Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.
+
+**Architecture:** First bundle format is schema=1, id, skills mapping names to relative SKILL.md paths, templates mapping names to relative Markdown paths, and files mapping every included relative path to sha256. First delivery allows regular UTF-8 Markdown only, at most 2 MiB/file and 10 MiB total; no symlinks, scripts, absolute paths, traversal, or undeclared files. Guidance remains untrusted input for the receiving harness. Add ai-dlc agents bundle import SOURCE --ref REF --id ID [--apply --expected-commit SHA]; preview can fetch to temporary storage but cannot change active files. Reuse existing Git source validation through a public shared helper while preserving profile-source tests; resolve an advertised ref to an exact commit and compare it again on apply. Apply vendors selected files plus a lock under .ai-dlc/bundles/ID. Project-only agents.bundles selects these IDs, so Git transports them between machines. Existing agents.skills remains shipped-skill selection. Resolve name collisions by refusing, never overwrite. No remote registry or automatic startup fetch. The --expected-commit flag is required for apply and must equal the previewed commit. Import operates on a bundle root containing bundle.json and its declared payload; Git metadata is excluded. References in Markdown never authorize execution. Add agents.bundles to project-only nested configuration validation; reject it in personal/machine layers in this first delivery.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [portable-workflow-bundles](../../../openspec/changes/portable-workflow-bundles/specs/portable-workflow-bundles/spec.md)
+
+## Global constraints
+
+No arbitrary installer/scripts, marketplace, dependency solver, new client adapter, remote auto-update, or changes to personal profile enrollment semantics.
+
+Milestone: M1. Dependencies: `component-capability-contract`, `connected-project-readiness`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+validate_bundle(root: Path, manifest: dict) -> dict returns a validated schema-1 manifest. resolve_bundle(source:str, ref:str, bundle_id:str, *, environ) -> candidate with resolved_commit and file hashes; it does not activate files. import_bundle(root:Path, candidate, *, apply:bool=False) -> {applied, changed, conflicts, resolved_commit}. The candidate type and cleanup lifecycle are defined in workflow_bundles.py; no active profile lock is mutated.
+
+### Files and ownership
+
+- Create src/ai_dlc/workflow_bundles.py
+- Modify src/ai_dlc/agents.py
+- Modify src/ai_dlc/cli.py
+- Modify src/ai_dlc/config.py
+- Test tests/test_workflow_bundles.py
+- Modify tests/test_rendering.py, tests/test_templates.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## First executable acceptance example
+
+The following is a target regression, to be added during implementation. It is not run in this documentation change.
+
+```python
+import pytest
+from ai_dlc.workflow_bundles import validate_bundle
+
+def test_bundle_rejects_path_escape(tmp_path):
+    manifest = {"schema": 1, "id": "example", "skills": {"example": "../SKILL.md"}, "templates": {}, "files": {"../SKILL.md": "0" * 64}}
+    with pytest.raises(ValueError):
+        validate_bundle(tmp_path, manifest)
+```
+
+Run it first and verify the failure is the missing specified behavior, then implement against the interfaces above.
+
+Tests are introduced incrementally: Task 1 covers only its delivered boundary;
+add later-task assertions when that task begins. Capture red then green within
+each task. Do not commit a deliberately failing suite or make future behavior
+pass with placeholders. The first acceptance example may span multiple tasks;
+add it at the task that owns its complete interface.
+
+### Task 1: Manifest and digest validation
+
+**Files:** tests/test_workflow_bundles.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Implement validate_bundle with malformed, oversized, traversal, symlink, extra-file, digest mismatch, and duplicate-name cases. Validate all assets before planning a write; imports and rendering remain Tasks 2 and 3.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 1.3 Implement validate_bundle with malformed, oversized, traversal, symlink, extra-file, digest mismatch, and duplicate-name cases. Validate all assets before planning a write; imports and rendering remain Tasks 2 and 3.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_workflow_bundles.py tests/test_profile_source.py tests/test_rendering.py tests/test_templates.py tests/test_config.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Pinned import preview/apply
+
+**Files:** src/ai_dlc/workflow_bundles.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Implement temporary source resolution, reviewed revision matching, vendored lock, and rollback on partial file errors. Preserve the existing profile-source security contract when sharing helpers.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 2.3 Implement temporary source resolution, reviewed revision matching, vendored lock, and rollback on partial file errors. Preserve the existing profile-source security contract when sharing helpers.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_workflow_bundles.py tests/test_profile_source.py tests/test_rendering.py tests/test_templates.py tests/test_config.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Client and template distribution
+
+**Files:** src/ai_dlc/agents.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Extend owned skill/template rendering and project-only config validation; demonstrate one external Markdown bundle in a fresh checkout, offline.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 3.3 Extend owned skill/template rendering and project-only config validation; demonstrate one external Markdown bundle in a fresh checkout, offline.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_workflow_bundles.py tests/test_profile_source.py tests/test_rendering.py tests/test_templates.py tests/test_config.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| WB-01: Pinned portable workflow assets | 1, 2 | Focused positive and refusal cases, then integration and required project checks. |
+| WB-02: Owned rendering and integrity | 1, 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+| WB-03: Direct use and offline continuation | 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate portable-workflow-bundles --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish portable-workflow-bundles` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-product-shaping-workflow.md
+++ b/docs/superpowers/plans/2026-09-05-product-shaping-workflow.md
@@ -1,0 +1,116 @@
+# Guide product discovery and feature selection for new and existing products Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.
+
+**Architecture:** Reuse existing discovery/PRD/inbox skills; do not create a competing PM lifecycle. Greenfield compares at least two feasible approaches plus doing nothing when meaningful. Brownfield records actual behavior, constraints, affected users, compatibility, and rollback needs. Separate user evidence from model hypotheses. Make priority a reasoned judgment using user impact, confidence in evidence, effort, and dependencies without fabricated numeric precision. UI exploration is optional and routes to design-pm-workflow only when the slice changes an interface. Small work can use a single brief; no mandatory PRD/design/ticket duplication.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [product-shaping-workflow](../../../openspec/changes/product-shaping-workflow/specs/product-shaping-workflow/spec.md)
+
+## Global constraints
+
+No invented interviews or user approval, automatic ticket publication during discovery, mandatory UI work, replacement specification system, or broad autonomous feature expansion.
+
+Milestone: M2. Dependencies: none; ready after the planning branch is integrated.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+The product brief is Markdown with stable sections: Audience and problem; Evidence and assumptions; Current behavior (brownfield); Options and trade-offs; Selected outcome; Scope and exclusions; Success evidence; Next slice; Unresolved decisions. Requirement IDs use RQ-001 style within the brief; one canonical brief owns those IDs. Output ends with proceed, investigate, or stop plus reasons, not an invented approval.
+
+### Files and ownership
+
+- Modify agents/skills/discovery/SKILL.md
+- Modify agents/skills/prd-draft/SKILL.md
+- Modify agents/skills/review-inbox/SKILL.md
+- Modify agents/templates/prd.md
+- Create agents/templates/product-brief.md
+- Create agents/examples/product-shaping/greenfield.md and brownfield.md
+- Update agents/skills.lock.json and managed/generated copies
+- Modify docs/workflows/greenfield.md, brownfield.md and matching project templates
+- Test tests/test_templates.py and tests/test_rendering.py
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## Behavioral review cases
+
+For each criterion below, preserve the input, produced artifact or observation, expected result, actual result, and evidence. Packaging checks only prove asset delivery; they do not substitute for these cases.
+
+- **PS-01 — Evidence-based product shaping:** The workflow SHALL distinguish observed evidence, user decisions, and hypotheses; it SHALL compare feasible options and identify a bounded outcome before proposing implementation.
+- **PS-02 — Separate greenfield and brownfield entry paths:** Greenfield guidance SHALL shape the smallest useful outcome; brownfield guidance SHALL inspect existing behavior and preserve explicit compatibility boundaries.
+- **PS-03 — Proportional handoff:** The workflow SHALL produce traceable outcome/requirement IDs and an explicit proceed, investigate, or stop decision; material unknowns SHALL remain visible and SHALL NOT become invented acceptance facts.
+
+### Task 1: Worked examples and review criteria
+
+**Files:** agents/examples/product-shaping/ plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Author one greenfield task and one brownfield task with evidence, options, excluded scope, RQ IDs, and a correct next action. Include a misleading feature request and contradictory requirements.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 1.3 Author one greenfield task and one brownfield task with evidence, options, excluded scope, RQ IDs, and a correct next action. Include a misleading feature request and contradictory requirements.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Skills and templates
+
+**Files:** agents/skills/discovery/SKILL.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Update the existing skills and PRD template using the examples; include exact output sections and decision rules. Follow skill-authoring guidance during implementation and retain upstream-provider routing.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 2.3 Update the existing skills and PRD template using the examples; include exact output sections and decision rules. Follow skill-authoring guidance during implementation and retain upstream-provider routing.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Distribution and behavioral cases
+
+**Files:** tests/test_templates.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Regenerate digest locks/client copies/templates; add packaging tests for assets and behavioral scenarios measuring decisions rather than just headings.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 3.3 Regenerate digest locks/client copies/templates; add packaging tests for assets and behavioral scenarios measuring decisions rather than just headings.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py tests/test_rendering.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| PS-01: Evidence-based product shaping | 1, 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| PS-02: Separate greenfield and brownfield entry paths | 1, 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| PS-03: Proportional handoff | 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate product-shaping-workflow --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish product-shaping-workflow` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md
+++ b/docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md
@@ -1,0 +1,128 @@
+# Carry product requirements into independently deliverable specifications and tickets Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.
+
+**Architecture:** New work records list dependency work IDs, requirement IDs, exact artifact references, and acceptance/verification text. Validate missing referenced local records, self-dependency, cycles, unsafe IDs, and absent local artifacts before publication. Dependency validation verifies graph integrity; it does not claim dependencies completed. work start checks dependency tracker state and fails explicitly on unfinished or unavailable dependencies; a terminal cancelled/duplicate item does not satisfy a completion dependency. Existing records with empty lists keep their current behavior. The native publish body includes scope, requirements, dependencies, artifacts, and acceptance plus the unchanged correlation marker. Re-publishing an already linked item remains idempotent and does not silently overwrite authored remote descriptions. Spec guidance creates one independently finishable OpenSpec change per behavior ticket; OpenSpec tasks are steps inside that ticket, not one ticket per checkbox. A shared parent epic has no completion gate over child specs.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** [spec-delivery-traceability](../../../openspec/changes/spec-delivery-traceability/specs/spec-delivery-traceability/spec.md)
+
+## Global constraints
+
+No automatic scope approval, duplicate spec store, spec-to-one-checkbox-ticket mapping, remote priority inference, or weakened finish gates.
+
+Milestone: M2. Dependencies: `product-shaping-workflow`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+Add optional Work fields depends_on: list[str]=[] and requirements: list[str]=[]. Add validate_work_graph(records:dict[str,dict])->list[str] and render_ticket_body(work:dict)->str in traceability.py. Requirements are stable brief/spec requirement identifiers, not duplicated spec prose. Add ai-dlc work validate WORK_ID --root PATH (read-only, 0 valid/1 invalid). No automated interpretation of arbitrary natural-language specifications.
+
+### Files and ownership
+
+- Modify agents/skills/spec-from-prd/SKILL.md
+- Create agents/templates/delivery-slice.md
+- Modify src/ai_dlc/workflow.py
+- Modify src/ai_dlc/cli.py
+- Create src/ai_dlc/traceability.py
+- Test tests/test_traceability.py
+- Modify tests/test_workflow.py, tests/test_cli.py
+- Update docs/workflows/design-to-implementation.md and generated templates
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## First executable acceptance example
+
+The following is a target regression, to be added during implementation. It is not run in this documentation change.
+
+```python
+from ai_dlc.traceability import validate_work_graph
+
+def test_dependency_cycle_is_reported():
+    records = {"a": {"id": "a", "depends_on": ["b"]}, "b": {"id": "b", "depends_on": ["a"]}}
+    errors = validate_work_graph(records)
+    assert any("cycle" in error.lower() for error in errors)
+```
+
+Run it first and verify the failure is the missing specified behavior, then implement against the interfaces above.
+
+Tests are introduced incrementally: Task 1 covers only its delivered boundary;
+add later-task assertions when that task begins. Capture red then green within
+each task. Do not commit a deliberately failing suite or make future behavior
+pass with placeholders. The first acceptance example may span multiple tasks;
+add it at the task that owns its complete interface.
+
+### Task 1: Pure graph validation and ticket rendering
+
+**Files:** src/ai_dlc/traceability.py, tests/test_traceability.py plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Implement validate_work_graph and render_ticket_body with missing ID, self/cycle, stable order and rich body cases. Preserve correlation values. Task 2 owns optional Work fields, filesystem artifact checks and mutation ordering; the pure graph function does not inspect files or services.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 1.3 Implement validate_work_graph and render_ticket_body with missing ID, self/cycle, stable order and rich body cases. Preserve correlation values. Task 2 owns optional Work fields, filesystem artifact checks and mutation ordering; the pure graph function does not inspect files or services.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_traceability.py tests/test_workflow.py tests/test_cli.py tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Workflow integration
+
+**Files:** src/ai_dlc/workflow.py plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Validate before mutation, expose work validate, check dependency completion before branch/start effects, and render richer descriptions on first create only.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 2.3 Validate before mutation, expose work validate, check dependency completion before branch/start effects, and render richer descriptions on first create only.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_traceability.py tests/test_workflow.py tests/test_cli.py tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Spec and task handoff guidance
+
+**Files:** agents/skills/spec-from-prd/SKILL.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** Update skill/template examples using PS requirement IDs; show an independently finishable change and a no-spec verification item; regenerate owned copies.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Add focused failing cases for this task's specified behavior and failure paths. Run the named focused suite and capture the expected failure before implementation.
+- [ ] 3.3 Update skill/template examples using PS requirement IDs; show an independently finishable change and a no-spec verification item; regenerate owned copies.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_traceability.py tests/test_workflow.py tests/test_cli.py tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| TR-01: Explicit traceability | 1, 2 | Focused positive and refusal cases, then integration and required project checks. |
+| TR-02: Valid dependency graph | 1, 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+| TR-03: Compatible rich publication | 2, 3 | Focused positive and refusal cases, then integration and required project checks. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Run `openspec validate spec-delivery-traceability --strict --no-interactive`, review against this plan, and archive only after all implementation tasks are complete. Update the work record to the exact archived path.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish spec-delivery-traceability` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/superpowers/plans/2026-09-05-workflow-quality-calibration.md
+++ b/docs/superpowers/plans/2026-09-05-workflow-quality-calibration.md
@@ -1,0 +1,110 @@
+# Evaluate product shaping and delivery guidance against baseline behavior Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Use superpowers:subagent-driven-development only when delegation is authorized. Steps use checkbox syntax for tracking.
+
+**Goal:** Measure whether the general product-to-delivery guidance improves decisions, scope control, and implementation handoff using human-labeled scenarios.
+
+**Architecture:** Prepare six original cases: ambiguous new product, unvalidated feature request, contradictory requirements, legacy compatibility change, risky migration, and tiny mechanical fix. Use four for calibration and hold back two until prompts are frozen. Compare existing guidance with revised guidance on matched inputs and equal declared budgets. Report decision accuracy, invented facts, unjustified scope growth, missing behavior/verification links, and human usefulness ratings. Record a dedicated approved budget before paid runs. Existing agents/evaluation.toml remains its own pending release gate and must not be relabeled completed by this smaller experiment.
+
+**Tech Stack:** Python 3.12, existing AI-DLC CLI/services, Markdown workflow assets, OpenSpec, and configured tracker/SCM adapters. Reuse existing dependencies; any new dependency requires a documented necessity and explicit review.
+
+**Spec:** No new formal behavior: this ticket verifies its predecessor contracts.
+
+## Global constraints
+
+No fabricated human ratings, automatic paid experiments, universal quality claims, or substitution for existing release evaluations.
+
+Milestone: M3. Dependencies: `product-shaping-workflow`, `spec-delivery-traceability`.
+
+## Execution contract
+
+- Read AGENTS.md, ai-dlc.toml, the current work record, docs/product-direction.md, the [shared implementation clarifications](../../design/framework-delivery.md#frozen-cross-ticket-contracts), and this ticket's specification (or predecessor contracts for verification work) before edits.
+- Prepare the checkout with `sh scripts/bootstrap.sh --source` and use its printed PATH. Work on the ticket's own branch after the planning branch is integrated.
+- Dependencies below must be completed and their artifacts available. Until TR-02 is implemented, check their tracker state and accepted evidence manually; do not add unsupported fields to the current Work schema.
+- Keep each requirement's implementation, tests, source documentation, and generated assets in the same change. Preserve unrelated edits and legacy Rust source.
+- Use existing native tools directly where appropriate. Existing repository checks and `ai-dlc work finish` remain the completion boundary.
+- For implementation of skills, read the installed skill-authoring instructions at execution time; do not change only generated .agents/.claude copies. For code, demonstrate each new observable failure with a focused regression before implementation.
+- Every task ends with its focused checks and a conventional commit. Final review requires `ai-dlc project check --required` and strict OpenSpec validation for behavior tickets.
+- A published backlog ticket is not completed implementation. Never tick tasks merely because a plan, template, or mocked result exists.
+
+## Scope and interfaces
+
+Each case records id, mode (greenfield/brownfield), prompt, evidence, material_unknowns, expected_decisions, disallowed_assumptions, requirement_ids, and held_out. Each run records exact asset/model versions, condition, actual usage/time, transcript, human judgments, and missing evidence.
+
+### Files and ownership
+
+- Create agents/evaluations/product-delivery/protocol.md
+- Create agents/evaluations/product-delivery/cases.json
+- Create docs/verification/product-delivery-evaluation.md
+- Update docs/release-verification.md
+
+All listed source/test paths are relative to the repository root. New paths are proposed deliverables, not claims that those files exist today.
+
+## Behavioral review cases
+
+For each criterion below, preserve the input, produced artifact or observation, expected result, actual result, and evidence. Packaging checks only prove asset delivery; they do not substitute for these cases.
+
+- **EV-01 — Original labeled cases:** Cases distinguish evidence from assumptions, cover both entry paths, and include correct investigate/stop/no-spec outcomes.
+- **EV-02 — Controlled comparison:** Comparison uses fixed recorded versions/budgets and held-out cases; full transcripts and actual costs/time are preserved where available.
+- **EV-03 — Human-grounded claims:** Human labels are supplied by humans; absent ratings remain pending, and results state observed scope without asserting universal model improvement.
+
+### Task 1: Case and rubric preparation
+
+**Files:** agents/evaluations/product-delivery/cases.json plus the directly affected source/generated files listed above.
+
+**Consumes:** The specification, fixtures/examples described above, and completed dependency interfaces.
+
+**Produces:** Create six cases and score keys; identify which judgments require humans and freeze the two held-out cases before prompt tuning.
+
+- [ ] 1.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 1.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 1.3 Create six cases and score keys; identify which judgments require humans and freeze the two held-out cases before prompt tuning.
+- [ ] 1.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 1.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 1.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 2: Comparison protocol
+
+**Files:** agents/evaluations/product-delivery/protocol.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 1's committed artifacts and the shared interface contract above.
+
+**Produces:** Record conditions, model/budget selection, repetitions, order balancing, transcript storage, and the decision metrics before execution.
+
+- [ ] 2.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 2.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 2.3 Record conditions, model/budget selection, repetitions, order balancing, transcript storage, and the decision metrics before execution.
+- [ ] 2.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 2.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 2.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+### Task 3: Run and review evidence
+
+**Files:** docs/verification/product-delivery-evaluation.md plus the directly affected source/generated files listed above.
+
+**Consumes:** Task 2's committed artifacts and the shared interface contract above.
+
+**Produces:** After the budget and human participation are available, run comparisons and publish results including negative outcomes, disagreements, and limitations.
+
+- [ ] 3.1 Inspect the named source and existing regression patterns; identify the exact requirement IDs covered by this task in the coverage table below.
+- [ ] 3.2 Prepare the concrete cases and expected observations above before authoring or executing the workflow; mark human/live-only observations pending.
+- [ ] 3.3 After the budget and human participation are available, run comparisons and publish results including negative outcomes, disagreements, and limitations.
+- [ ] 3.4 Run `uv run --locked --no-sync pytest -q tests/test_templates.py` after the listed new tests exist. Expected: all focused tests pass; investigate rather than skip failures.
+- [ ] 3.5 Review the result against each mapped requirement, including excluded scope and compatibility; update the OpenSpec task checkboxes only for delivered behavior.
+- [ ] 3.6 Commit only this task's related files with a conventional prefix and an outcome-focused message; carry exact commit/evidence into the handoff.
+
+## Requirement coverage
+
+| Requirement / verification criterion | Tasks | Verification |
+| --- | --- | --- |
+| EV-01: Original labeled cases | 1, 2 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| EV-02: Controlled comparison | 1, 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+| EV-03: Human-grounded claims | 2, 3 | Recorded behavioral case and evidence; unresolved human/live results remain pending. |
+
+## Completion and handoff
+
+- [ ] Run `ai-dlc project check --required`; inspect all five outcomes.
+- [ ] Create/link the PR, complete review and required CI, and use `ai-dlc work finish workflow-quality-calibration` only after merge evidence exists.
+- [ ] Leave a handoff with work/ticket ID, branch and revision, delivered interfaces, checks and evidence locations, unresolved findings, and the next dependency-unblocked ticket.
+
+Stop and report a blocked task if a dependency is incomplete, an accepted interface conflicts with existing behavior, a required live environment is unavailable, or a required human label/budget is absent. Continue independent local preparation where possible. Do not invent missing product decisions or broaden scope to clear a blocker.

--- a/docs/workflows/design-to-implementation.md
+++ b/docs/workflows/design-to-implementation.md
@@ -5,6 +5,13 @@ implementation. A design explains intent, journeys, constraints, boundaries,
 and decisions. It does not duplicate a PRD, formal specification, tracker, or
 implementation diff.
 
+Begin with a shaped outcome: evidence, assumptions, alternatives, and the next
+worthwhile increment. UI/UX exploration applies when the increment changes an
+interface; API, infrastructure, and migration work use suitable design methods.
+The planned [product-shaping workflow](../../openspec/changes/product-shaping-workflow/proposal.md)
+and [traceability change](../../openspec/changes/spec-delivery-traceability/proposal.md)
+extend this handoff without introducing a second specification system.
+
 [Back to the workflow map](../development-workflow.md)
 
 ## The handoff contract

--- a/docs/workflows/tool-map.md
+++ b/docs/workflows/tool-map.md
@@ -4,6 +4,11 @@ The lifecycle uses stable roles; `ai-dlc.toml` selects their current providers.
 This page records how the default AI-DLC toolset participates without making a
 vendor part of the lifecycle definition.
 
+Installed tool use, harness guidance, and provider adapters are complementary.
+Agents can use native tools directly; the configured services provide specific
+validation and completion boundaries. The [roadmap](../roadmap.md) distinguishes
+planned component/workflow support from the current interfaces listed here.
+
 [Back to the workflow map](../development-workflow.md)
 
 ## Role to provider mapping

--- a/openspec/changes/component-capability-contract/design.md
+++ b/openspec/changes/component-capability-contract/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.
+
+Excluded: No package registry, remote downloads, new provider operations, model selection, or changes to finish gates.
+
+## Decisions
+
+Component schema 1 contains id, roles, modules, guidance, required_config. Modules name existing entries in modules/catalog.toml; guidance is a list of repository/package-relative Markdown paths. Built-ins are indexed by provider kind. An optional providers.<id>.component overrides the component ID. Optional providers.<id>.component_manifest and component_manifest_sha256 select a checked-in JSON manifest verified before parsing. Unknown fields, duplicate IDs, unsafe paths, missing hashes, unknown modules, and incompatible roles fail validation. No manifest command strings or installers are executed. Native adapters remain in the existing provider registry.
+
+### Interface contract
+
+resolve_components(config: dict, catalog: dict) -> dict returns {schema: 1, components: [{id, provider, role, modules, guidance, required_config}], unresolved: [{provider, role, reason}]}. Lists are sorted by stable IDs. This function is pure and accepts only explicitly selected roles; the caller excludes compatibility-only base defaults.
+
+### Dependency contract
+
+No feature dependency. Begin after the planning documentation is integrated.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- CC-01: exercise openspec is selected without its module and the corresponding expected result in the formal spec.
+- CC-02: exercise custom metadata is altered and the corresponding expected result in the formal spec.
+- CC-03: exercise an alternative tracker is selected and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-component-capability-contract.md).

--- a/openspec/changes/component-capability-contract/proposal.md
+++ b/openspec/changes/component-capability-contract/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M1.
+
+## What Changes
+
+- Define schema-1 fixtures for openspec, linear, github-issues and two synthetic providers; add cases for missing module, unknown component, duplicate IDs, tampered digest, path escape, and no selected roles.
+- Implement catalog validation and resolve_components; keep installation, network, writes, and provider operations outside the resolver. Preserve unresolved-provider diagnostics.
+- Validate the three optional provider metadata fields and machine-layer refusal; document a complete third-party manifest example and verify packaged component data.
+
+## Capabilities
+
+### New Capabilities
+
+- `component-capability-contract`: Resolve explicitly selected provider roles into a deterministic, versioned description of required tools, guidance, configuration, and checks.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Create src/ai_dlc/components.py
+- Create modules/components.json
+- Modify src/ai_dlc/config.py
+- Test tests/test_components.py
+- Modify tests/test_config.py
+
+Dependencies: none.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-component-capability-contract.md).

--- a/openspec/changes/component-capability-contract/specs/component-capability-contract/spec.md
+++ b/openspec/changes/component-capability-contract/specs/component-capability-contract/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: CC-01 Deterministic capability resolution
+
+The resolver SHALL produce stable component requirements for each explicitly selected role, deduplicate installation modules, and report an unresolved provider without silently selecting another provider.
+
+#### Scenario: OpenSpec is selected without its module
+- **WHEN** a project selects the OpenSpec provider but its personal module list contains only core and python
+- **THEN** resolution identifies openspec as a required module and includes the provider guidance references
+
+### Requirement: CC-02 Verified extension metadata
+
+Custom component metadata SHALL be repository-relative, digest-verified, schema-validated data. It SHALL refer to existing installation recipes and SHALL NOT authorize executable commands.
+
+#### Scenario: Custom metadata is altered
+- **WHEN** the manifest bytes differ from the configured SHA-256
+- **THEN** resolution fails before loading guidance or planning installations
+
+### Requirement: CC-03 Compatibility and provenance
+
+Existing schema-4 configurations SHALL remain valid; component metadata SHALL NOT weaken project checks or silently rebind active work.
+
+#### Scenario: An alternative tracker is selected
+- **WHEN** new work selects a registered executable provider and a matching component manifest
+- **THEN** the stable tracker responsibility resolves through the declared component while previously bound work retains its existing provider

--- a/openspec/changes/component-capability-contract/tasks.md
+++ b/openspec/changes/component-capability-contract/tasks.md
@@ -1,0 +1,24 @@
+## 1. Validated component catalog
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Implement catalog loading/validation with schema-1 fixtures for openspec, linear, github-issues and two synthetic providers. Reject missing modules, duplicate IDs, digest mismatches and unsafe paths; ship referenced built-in guidance. Keep role resolution for Task 2 and provider configuration integration for Task 3.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Pure resolution
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Implement catalog validation and resolve_components; keep installation, network, writes, and provider operations outside the resolver. Preserve unresolved-provider diagnostics.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. Configuration integration
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Validate the three optional provider metadata fields and machine-layer refusal; document a complete third-party manifest example and verify packaged component data.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-component-capability-contract.md).

--- a/openspec/changes/connected-project-readiness/design.md
+++ b/openspec/changes/connected-project-readiness/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.
+
+Excluded: No credential auto-loading, automatic account choice, new client support claim, hosted control plane, or weakening of existing doctor/finish behavior.
+
+## Decisions
+
+Add ai-dlc project readiness --root PATH (read-only; exit 0 only when required checks are ready, else 1). Dimensions are tool, configuration, credential, guidance, and provider-health. Use catalog verify commands through a bounded injected probe; no installs/network for plain readiness, provider-health remains unverified unless existing explicit health inspection was requested through doctor. Provider-health is informational in offline readiness. Extend setup plan/apply and machine plan/apply with optional --root; root-aware planning unions declared modules with resolved component modules without editing the profile. Apply follows the existing explicit mutation command. Guidance readiness checks that the selected harness receives an index pointing to real configured-provider instructions. Existing root/machine doctor readiness contract is preserved, with the richer project report added under project_readiness.
+
+### Interface contract
+
+inspect_readiness(root: Path, config: dict, *, environ: Mapping[str,str], probe: Callable[[list[str]],dict]) -> dict returns {schema:1, ready:bool, checks:[{component, dimension, status, reason, next_action}], qualification:'not-assessed'}. status is ready, missing, blocked, or unverified. Extend MachineManager.plan/apply with optional root: Path | None = None; omitted root retains current behavior.
+
+### Dependency contract
+
+- component-capability-contract: consume its committed documented interfaces; do not implement an incompatible local substitute.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- RD-01: exercise a project requires an absent tool and the corresponding expected result in the formal spec.
+- RD-02: exercise tool installation alone is insufficient and the corresponding expected result in the formal spec.
+- RD-03: exercise a second environment is headless and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-connected-project-readiness.md).

--- a/openspec/changes/connected-project-readiness/proposal.md
+++ b/openspec/changes/connected-project-readiness/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M1.
+
+## What Changes
+
+- Add injected-probe tests for absent binary, absent guidance, absent env key, valid offline requirements, and headless capability; test that outputs never contain credential values.
+- Forward optional root through public commands, manager, and provisioning; union modules using CC-01 and preserve explicit profile/machine precedence and no-root behavior.
+- Render an owned provider/tool index into supported client guidance; implement project readiness and add diagnostics to doctor without overriding machine enrollment failures.
+
+## Capabilities
+
+### New Capabilities
+
+- `connected-project-readiness`: Join selected provider requirements with machine provisioning and expose actionable project readiness without confusing it with release certification.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Create src/ai_dlc/readiness.py
+- Modify src/ai_dlc/cli.py
+- Modify src/ai_dlc/machine.py
+- Modify src/ai_dlc/provision.py
+- Modify src/ai_dlc/agents.py
+- Test tests/test_readiness.py
+- Modify tests/test_machine.py, tests/test_cli.py, tests/test_rendering.py
+
+Dependencies: component-capability-contract.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-connected-project-readiness.md).

--- a/openspec/changes/connected-project-readiness/specs/connected-project-readiness/spec.md
+++ b/openspec/changes/connected-project-readiness/specs/connected-project-readiness/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: RD-01 Connected provisioning plan
+
+Root-aware setup SHALL resolve explicit project and profile selections into required tool modules and guidance, preserving existing no-root command behavior and authored files.
+
+#### Scenario: A project requires an absent tool
+- **WHEN** the personal profile omits the OpenSpec installation module while the project explicitly selects OpenSpec
+- **THEN** the root-aware plan includes that module with its provider-selection reason and applies nothing until setup apply is invoked
+
+### Requirement: RD-02 Readiness is actionable and scoped
+
+Project readiness SHALL separately identify tool, configuration, credential, and guidance failures with next actions; it SHALL inspect only credential presence and SHALL NOT read secret files automatically.
+
+#### Scenario: Tool installation alone is insufficient
+- **WHEN** OpenSpec is executable but its selected harness guidance is missing
+- **THEN** readiness reports the guidance gap and does not declare the project ready
+
+### Requirement: RD-03 Environment consistency preserves local identity
+
+Equivalent profile/project revisions SHALL resolve equivalent portable requirements with independent local bindings; unsupported capabilities SHALL be explicit.
+
+#### Scenario: A second environment is headless
+- **WHEN** a selected optional component requires a desktop while the target is headless
+- **THEN** the report names the unsupported capability without substituting another provider or claiming full target qualification

--- a/openspec/changes/connected-project-readiness/tasks.md
+++ b/openspec/changes/connected-project-readiness/tasks.md
@@ -1,0 +1,24 @@
+## 1. Readiness model
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Implement inspect_readiness with injected probes and tests for absent binary, absent guidance, absent environment key, valid offline requirements, and headless capability. Prove outputs never contain credential values. Keep provisioning and CLI exposure for Tasks 2 and 3.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Root-aware setup
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Forward optional root through public commands, manager, and provisioning; union modules using CC-01 and preserve explicit profile/machine precedence and no-root behavior.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. Harness guidance and reporting
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Render an owned provider/tool index into supported client guidance; implement project readiness and add diagnostics to doctor without overriding machine enrollment failures.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-connected-project-readiness.md).

--- a/openspec/changes/design-pm-workflow/design.md
+++ b/openspec/changes/design-pm-workflow/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The [product brief](../../../docs/design/design-pm.md) defines the opportunity and
+example rubric. This is an optional M2 workflow, after product shaping and delivery
+traceability, within the [framework direction](../../../docs/product-direction.md). AI-DLC already
+distributes skills/templates and preserves generated ownership. Its existing
+skill evaluation protocol is pending and evaluates different behaviors.
+
+## Goals / Non-Goals
+
+Goals: give a harness usable brief/rubric/review instructions, durable continuation
+artifacts, explicit evidence rules, and a bounded revision pattern.
+
+Non-goals: a mandatory agent runtime, UI implementation, automatic taste judgment,
+new finish gates, forced model selection, and unverified client integrations.
+
+## Decisions
+
+1. Package Markdown templates and skill guidance through current asset mechanisms.
+   This reaches the harness in its existing environment. A dedicated service is
+   unnecessary for the initial workflow; automation can follow observed need.
+2. Extend existing product/discovery/design handoffs instead of introducing a second
+   PRD lifecycle. OpenSpec owns behavioral contracts, the brief owns rationale,
+   and iteration reports own observations. Link these artifacts.
+3. Separate required checks from rated criteria. Required failures and missing
+   evidence block acceptance regardless of any optional aggregate score.
+4. Keep evaluation inputs and candidate identity explicit. A separate session or
+   human can provide independent review where native delegation is absent.
+5. Ship original examples and a calibration protocol; use a separately budgeted
+   experiment to determine actual quality lift. Do not reuse the pending generic
+   skill evaluation budget without an explicit change to that experiment.
+
+## Risks / Trade-offs
+
+- Evaluator preference becomes a hidden product requirement → tie criteria to the
+  brief, preserve human disagreements, and version changes.
+- Scores reward complexity → include task fit, regression checks, and explicit budgets.
+- Artifacts become ceremony → create them only for work needing design evaluation;
+  keep a single contract with linked evidence rather than duplicated documents.
+- Cross-client behavior differs → qualify each client separately and report absent
+  capabilities without pretending to have observed the interface.
+
+## Migration Plan
+
+Add source skills/templates and update their managed/generated counterparts using
+the existing renderer. Extend the project design handoff with links to the new
+optional workflow. Verify packaging and owned-update/conflict behavior. Roll back
+by reverting the asset addition through the same ownership mechanism; preserve
+project-authored briefs and evidence.
+
+## Execution contract
+
+Implement design-brief and design-evaluate using Markdown artifacts and the
+selected existing generation tools. Consume the shaped product brief and delivery
+slice; preserve their requirement IDs. The [execution plan](../../../docs/superpowers/plans/2026-09-05-design-pm-workflow.md)
+defines exact files, responsibilities, sample defaults, and verification. Human
+calibration remains separate work; project-specific references and budgets are
+inputs to each evaluation rather than global framework requirements.

--- a/openspec/changes/design-pm-workflow/proposal.md
+++ b/openspec/changes/design-pm-workflow/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+AI-DLC equips harnesses with portable development tools and guidance, but its
+design handoff lacks a repeatable way to turn subjective goals into observable
+quality criteria. Developers need a reusable brief, evaluation contract, and
+revision workflow that can travel with the project between machines and harnesses.
+
+## What Changes
+
+- Add portable Design PM guidance and templates for briefs, rubrics, evidence,
+  independent review, revision budgets, and candidate selection.
+- Integrate these assets with existing skill distribution and generated projects.
+- Provide original examples that distinguish observed behavior, subjective
+  judgment, missing evidence, and human decisions.
+- Preserve direct use of installed design/browser tools and existing completion
+  gates; introduce no required orchestration service or new CLI command.
+
+This is a planned optional UI/UX workflow within milestone M2. Dependencies are
+product-shaping-workflow and spec-delivery-traceability. It does not define the
+overall framework direction. No implementation or live evaluation is complete.
+
+## Capabilities
+
+### New Capabilities
+
+- `design-pm`: portable design evaluation contracts and evidence-preserving iteration.
+
+### Modified Capabilities
+
+None. Existing portable enrollment and completion requirements remain unchanged.
+
+## Impact
+
+Expected surfaces: `agents/skills/`, `agents/templates/`, skill integrity metadata,
+generated client assets, `project-templates/`, design workflow documentation, and
+generation/packaging tests. Additional clients require separate qualification.
+
+Rationale and proposed example rubric: [Design PM brief](../../../docs/design/design-pm.md).
+Work: [design-pm-workflow](../../../.ai-dlc/work/design-pm-workflow.toml).
+Empirical calibration is a separate [work item](../../../.ai-dlc/work/design-pm-calibration.toml).

--- a/openspec/changes/design-pm-workflow/specs/design-pm/spec.md
+++ b/openspec/changes/design-pm-workflow/specs/design-pm/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: DP-01 Design intent precedes evaluation
+
+The Design PM workflow SHALL provide a portable brief and a versioned evaluation
+contract identifying audience, primary journey, constraints, criterion IDs,
+evidence methods, score anchors, required checks, and run budget before generation.
+It SHALL distinguish proposed defaults from human-approved task decisions.
+
+#### Scenario: A vague design request becomes an evaluable task
+- **WHEN** a user requests a good interface without criteria
+- **THEN** the workflow produces a draft brief and concrete checks with explicit
+  assumptions, and identifies material unresolved product decisions before implementation
+
+#### Scenario: An established design system constrains the work
+- **WHEN** the brief requires existing brand components
+- **THEN** evaluation judges choices against that requirement and does not penalize
+  appropriate component reuse merely for lacking novelty
+
+### Requirement: DP-02 Evaluation preserves evidence and uncertainty
+
+Evaluation reports SHALL identify the candidate revision, rubric version,
+reviewer/session, tools used, tested states and viewports, criterion-level evidence,
+findings, and verdict. Behavioral checks SHALL use pass, fail, or unverified;
+subjective criteria SHALL use declared score anchors or unverified. Missing tool
+access or evidence SHALL NOT count as passing behavior.
+
+#### Scenario: A polished candidate has a broken journey
+- **WHEN** a required interaction fails while visual criteria score highly
+- **THEN** the report records the failed check and blocks contract acceptance
+
+#### Scenario: Only a static mockup is available
+- **WHEN** interaction verification requires a running application
+- **THEN** the report can evaluate observed visual criteria but records the
+  interaction checks as unverified
+
+### Requirement: DP-03 Independent review is explicit
+
+The workflow SHALL define generator and evaluator responsibilities independently.
+An independent evaluator SHALL receive the brief, contract, candidate, and access
+instructions and SHALL form findings through observation. The generator's claims
+SHALL NOT substitute for evidence. Self-review SHALL be labeled as self-review.
+
+#### Scenario: A harness lacks agent delegation
+- **WHEN** parallel or delegated agents are unavailable
+- **THEN** the workflow provides a separate-session or human-review handoff and
+  does not report self-review as independent evaluation
+
+### Requirement: DP-04 Iteration respects budgets and candidate identity
+
+The workflow SHALL record iteration and time or token limits before a run, retain
+candidate identities and reports, and permit selection of an earlier candidate.
+It SHALL stop at contract satisfaction, budget exhaustion, a material unresolved
+decision, or the declared plateau condition. Stopping SHALL NOT imply passing.
+Material rubric changes SHALL create a new version and require reevaluation of
+candidates compared under that version.
+
+#### Scenario: Budget expires with a failed required check
+- **WHEN** the run reaches its limit without a qualifying candidate
+- **THEN** it records needs-work, unresolved findings, and the next action
+
+#### Scenario: A later revision regresses
+- **WHEN** a previous candidate meets the contract better than the latest revision
+- **THEN** selection can retain the previous candidate with its matching evidence
+
+### Requirement: DP-05 Guidance travels through existing project distribution
+
+AI-DLC SHALL distribute Design PM instructions, templates, and examples through
+its existing managed-asset and project-template mechanisms. The workflow SHALL
+be usable through readable project artifacts and installed tools without a new
+mandatory service. Updates SHALL preserve authored content and report conflicts.
+Client-specific support SHALL be distinguished from portable instructions.
+
+#### Scenario: A developer changes machine or harness
+- **WHEN** a subsequent session opens the project
+- **THEN** its saved brief, contract, candidate references, findings, and decision
+  explain continuation without requiring the prior chat transcript
+
+#### Scenario: A generated rubric has local edits
+- **WHEN** asset synchronization conflicts with authored content
+- **THEN** the existing ownership/conflict workflow preserves it and reports the conflict
+
+### Requirement: DP-06 Calibration claims require measured evidence
+
+The package SHALL include a documented calibration protocol and original sample
+cases for required-defect detection and subjective rating. Results SHALL identify
+the model/harness, criteria, budgets, comparisons, human ratings, and limitations.
+Unrun experiments and absent human review SHALL remain explicit. Sample assets
+or fixture tests SHALL NOT establish live design-quality improvement.
+
+#### Scenario: Distribution tests pass before calibration runs
+- **WHEN** generated assets and fixtures pass but no human-rated experiment exists
+- **THEN** reporting states that distribution is verified and quality improvement
+  remains unevaluated

--- a/openspec/changes/design-pm-workflow/tasks.md
+++ b/openspec/changes/design-pm-workflow/tasks.md
@@ -1,0 +1,31 @@
+# Optional UI/UX workflow tasks
+
+Prerequisites: product-shaping-workflow and spec-delivery-traceability must be
+delivered first. Follow the [execution plan](../../../docs/superpowers/plans/2026-09-05-design-pm-workflow.md)
+for file ownership, examples, checks and handoff. Its Task 1 covers sections 1
+and 4.1; Task 2 covers section 2; Task 3 covers sections 3 and 4.2–4.4 below.
+These are implementation checkboxes, not evidence that planning completed them.
+
+## 1. Review and artifact contract
+
+- [ ] 1.1 Review the product brief, proposed rubric defaults, and capability scenarios before implementation.
+- [ ] 1.2 Finalize brief, rubric, evaluation, and selection templates with criterion/candidate/version identity.
+
+## 2. Portable guidance
+
+- [ ] 2.1 Add guidance for brief-to-criteria translation with original anchored examples.
+- [ ] 2.2 Add generation and independent-evaluation responsibilities plus separate-session/human fallback.
+- [ ] 2.3 Define budget, plateau, regression, evidence, and rubric-change behavior in the iteration guidance.
+
+## 3. Distribution and handoff
+
+- [ ] 3.1 Integrate source assets, integrity metadata, managed rendering, and project templates.
+- [ ] 3.2 Extend the design handoff and tool map without changing existing finish gates.
+- [ ] 3.3 Verify generated ownership, authored-content preservation, packaging, and continuation artifacts.
+
+## 4. Calibration protocol and validation
+
+- [ ] 4.1 Supply an original example case set and a protocol for human calibration and held-out comparisons.
+- [ ] 4.2 Verify failure/unverified/score handling through meaningful workflow scenarios; distinguish fixtures from live results.
+- [ ] 4.3 Run required project checks, validate OpenSpec, and complete source review.
+- [ ] 4.4 Archive the implemented specification, link PR/CI evidence, and complete through the configured finish boundary.

--- a/openspec/changes/linear-provider-onboarding/design.md
+++ b/openspec/changes/linear-provider-onboarding/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.
+
+Excluded: No API-key creation, Linear Project creation, issue mutation, organization switching, or automatic rebind. Use existing sandbox only for authorized live reads.
+
+## Decisions
+
+Add ai-dlc provider connect PROVIDER --root PATH. Without selection flags it prints complete discovery and exits without writes. Preview flags are --organization UUID --team UUID --in-progress UUID --closed UUID; --apply additionally writes local shared non-secret mappings. Use existing token_env; do not create or rotate keys. Validate selected team belongs to the selected organization result, started/completed state types and team membership. Multiple states are always listed; never infer In Progress from first started state. Paginate all selected discovery collections or fail incomplete. Preserve unrelated TOML content using a reviewed TOML editing approach; tests must assert comments and unrelated values survive. Refuse changed existing mappings when local work is already bound; point to explicit rebind. Preview can save its non-secret plan with --plan-file PATH under .ai-dlc/local. Apply consumes --plan-file PATH with --apply, revalidates selections against fresh discovery, and checks before_digest immediately before the atomic write; it never silently recomputes a different approved plan.
+
+### Interface contract
+
+discover_linear(settings: dict, *, environ: Mapping[str,str], client) -> dict returns {organization:{id,name,urlKey}, teams:[{id,name,key,states:[{id,name,type}]}]}. plan_linear_connection(config:dict, discovery:dict, selection:dict) -> dict returns {provider, before_digest, selected, patch}; selection requires organization_id, team_id, in_progress, closed. apply_linear_connection(path:Path, plan:dict) verifies the before digest and atomically replaces only selected provider settings.
+
+### Dependency contract
+
+- component-capability-contract: consume its committed documented interfaces; do not implement an incompatible local substitute.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- LN-01: exercise two started states exist and the corresponding expected result in the formal spec.
+- LN-02: exercise configuration changes after preview and the corresponding expected result in the formal spec.
+- LN-03: exercise an existing binding would change and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md).

--- a/openspec/changes/linear-provider-onboarding/proposal.md
+++ b/openspec/changes/linear-provider-onboarding/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M1.
+
+## What Changes
+
+- Cover multiple teams, duplicate names, two started states, pagination, authorization failure, and incomplete result handling with injected httpx responses.
+- Validate UUID membership/types and config digest; preserve comments and unrelated sections; prove an invalid selection writes nothing.
+- Implement provider connect preview/apply, credential-redacted errors, and binding-drift refusal. Add a sandbox read-only walkthrough procedure.
+
+## Capabilities
+
+### New Capabilities
+
+- `linear-provider-onboarding`: Replace manual team/status UUID hunting with explicit, read-only discovery and a reviewed local configuration update.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Create src/ai_dlc/provider_onboarding.py
+- Modify src/ai_dlc/providers/linear.py
+- Modify src/ai_dlc/cli.py
+- Test tests/test_provider_onboarding.py
+- Modify tests/test_cli.py, tests/test_rebind.py
+
+Dependencies: component-capability-contract.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md).

--- a/openspec/changes/linear-provider-onboarding/specs/linear-provider-onboarding/spec.md
+++ b/openspec/changes/linear-provider-onboarding/specs/linear-provider-onboarding/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: LN-01 Complete scoped discovery
+
+Onboarding SHALL query only the configured credential's organization, teams, and workflow states, consume pagination, and report incomplete or failed discovery without mutations.
+
+#### Scenario: Two started states exist
+- **WHEN** a team exposes In Progress and In Review as started states
+- **THEN** both are presented and explicit state selection is required
+
+### Requirement: LN-02 Validated local preview and apply
+
+Onboarding SHALL validate organization, team, and state membership and types before showing a non-secret patch; apply SHALL require unchanged source configuration and preserve unrelated content.
+
+#### Scenario: Configuration changes after preview
+- **WHEN** the configuration digest differs from the reviewed plan
+- **THEN** apply refuses the stale patch without modifying the file
+
+### Requirement: LN-03 Existing work and credentials stay stable
+
+Onboarding SHALL retain the project's credential variable and refuse silent mapping changes for already bound work; it SHALL NOT create or modify remote issues or accounts.
+
+#### Scenario: An existing binding would change
+- **WHEN** apply proposes a new team for locally bound work
+- **THEN** the operation refuses and names the explicit rebind workflow

--- a/openspec/changes/linear-provider-onboarding/tasks.md
+++ b/openspec/changes/linear-provider-onboarding/tasks.md
@@ -1,0 +1,24 @@
+## 1. Paginated discovery
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Implement discover_linear with injected httpx responses covering multiple teams, duplicate names, two started states, pagination, authorization failure, and incomplete result refusal. Expose no mutations or CLI apply in this task.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Selection and guarded local write
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Implement plan_linear_connection and apply_linear_connection: validate selection membership/types and config digest, preserve comments and unrelated sections, write atomically, and prove invalid/stale selections write nothing. Task 3 owns CLI wiring and fresh remote membership checks.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. CLI and guarded apply
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Implement provider connect preview/apply, credential-redacted errors, and binding-drift refusal. Add a sandbox read-only walkthrough procedure.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-linear-provider-onboarding.md).

--- a/openspec/changes/portable-workflow-bundles/design.md
+++ b/openspec/changes/portable-workflow-bundles/design.md
@@ -1,0 +1,41 @@
+## Context
+
+Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.
+
+Excluded: No arbitrary installer/scripts, marketplace, dependency solver, new client adapter, remote auto-update, or changes to personal profile enrollment semantics.
+
+## Decisions
+
+First bundle format is schema=1, id, skills mapping names to relative SKILL.md paths, templates mapping names to relative Markdown paths, and files mapping every included relative path to sha256. First delivery allows regular UTF-8 Markdown only, at most 2 MiB/file and 10 MiB total; no symlinks, scripts, absolute paths, traversal, or undeclared files. Guidance remains untrusted input for the receiving harness. Add ai-dlc agents bundle import SOURCE --ref REF --id ID [--apply --expected-commit SHA]; preview can fetch to temporary storage but cannot change active files. Reuse existing Git source validation through a public shared helper while preserving profile-source tests; resolve an advertised ref to an exact commit and compare it again on apply. Apply vendors selected files plus a lock under .ai-dlc/bundles/ID. Project-only agents.bundles selects these IDs, so Git transports them between machines. Existing agents.skills remains shipped-skill selection. Resolve name collisions by refusing, never overwrite. No remote registry or automatic startup fetch. The --expected-commit flag is required for apply and must equal the previewed commit. Import operates on a bundle root containing bundle.json and its declared payload; Git metadata is excluded. References in Markdown never authorize execution. Add agents.bundles to project-only nested configuration validation; reject it in personal/machine layers in this first delivery.
+
+### Interface contract
+
+validate_bundle(root: Path, manifest: dict) -> dict returns a validated schema-1 manifest. resolve_bundle(source:str, ref:str, bundle_id:str, *, environ) -> candidate with resolved_commit and file hashes; it does not activate files. import_bundle(root:Path, candidate, *, apply:bool=False) -> {applied, changed, conflicts, resolved_commit}. The candidate type and cleanup lifecycle are defined in workflow_bundles.py; no active profile lock is mutated.
+
+### Dependency contract
+
+- component-capability-contract: consume its committed documented interfaces; do not implement an incompatible local substitute.
+- connected-project-readiness: consume its committed documented interfaces; do not implement an incompatible local substitute.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- WB-01: exercise a source ref moves before apply and the corresponding expected result in the formal spec.
+- WB-02: exercise an imported skill has a local edit and the corresponding expected result in the formal spec.
+- WB-03: exercise a fresh checkout has no network and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md).

--- a/openspec/changes/portable-workflow-bundles/proposal.md
+++ b/openspec/changes/portable-workflow-bundles/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M1.
+
+## What Changes
+
+- Add malformed, oversized, traversal, symlink, extra-file, digest mismatch, and duplicate-name cases. Validate all assets before planning a write.
+- Implement temporary source resolution, reviewed revision matching, vendored lock, and rollback on partial file errors. Preserve the existing profile-source security contract when sharing helpers.
+- Extend owned skill/template rendering and project-only config validation; demonstrate one external Markdown bundle in a fresh checkout, offline.
+
+## Capabilities
+
+### New Capabilities
+
+- `portable-workflow-bundles`: Make a replaceable workflow bundle reproducible in the project repository and discoverable to the harness using existing managed rendering.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Create src/ai_dlc/workflow_bundles.py
+- Modify src/ai_dlc/agents.py
+- Modify src/ai_dlc/cli.py
+- Modify src/ai_dlc/config.py
+- Test tests/test_workflow_bundles.py
+- Modify tests/test_rendering.py, tests/test_templates.py
+
+Dependencies: component-capability-contract, connected-project-readiness.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md).

--- a/openspec/changes/portable-workflow-bundles/specs/portable-workflow-bundles/spec.md
+++ b/openspec/changes/portable-workflow-bundles/specs/portable-workflow-bundles/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: WB-01 Pinned portable workflow assets
+
+Imported workflow bundles SHALL record source, exact resolved revision, and complete file digests; preview SHALL leave active project and client files unchanged.
+
+#### Scenario: A source ref moves before apply
+- **WHEN** apply resolves different content from the previewed revision
+- **THEN** the import requires a fresh preview and does not activate changed content
+
+### Requirement: WB-02 Owned rendering and integrity
+
+Bundle validation SHALL reject unsafe, undeclared, tampered, or colliding assets before rendering; owned updates SHALL preserve authored modifications.
+
+#### Scenario: An imported skill has a local edit
+- **WHEN** a later import would overwrite that edit
+- **THEN** the existing ownership workflow reports the conflict and preserves the edited file
+
+### Requirement: WB-03 Direct use and offline continuation
+
+Selected vendored guidance SHALL be discoverable in supported harnesses and usable offline; instructions SHALL NOT depend on an AI-DLC daemon or prior chat.
+
+#### Scenario: A fresh checkout has no network
+- **WHEN** the committed bundle and lock are valid
+- **THEN** the harness can discover the selected guidance from the checkout without contacting its source

--- a/openspec/changes/portable-workflow-bundles/tasks.md
+++ b/openspec/changes/portable-workflow-bundles/tasks.md
@@ -1,0 +1,24 @@
+## 1. Manifest and digest validation
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Implement validate_bundle with malformed, oversized, traversal, symlink, extra-file, digest mismatch, and duplicate-name cases. Validate all assets before planning a write; imports and rendering remain Tasks 2 and 3.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Pinned import preview/apply
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Implement temporary source resolution, reviewed revision matching, vendored lock, and rollback on partial file errors. Preserve the existing profile-source security contract when sharing helpers.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. Client and template distribution
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Extend owned skill/template rendering and project-only config validation; demonstrate one external Markdown bundle in a fresh checkout, offline.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-portable-workflow-bundles.md).

--- a/openspec/changes/product-shaping-workflow/design.md
+++ b/openspec/changes/product-shaping-workflow/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.
+
+Excluded: No invented interviews or user approval, automatic ticket publication during discovery, mandatory UI work, replacement specification system, or broad autonomous feature expansion.
+
+## Decisions
+
+Reuse existing discovery/PRD/inbox skills; do not create a competing PM lifecycle. Greenfield compares at least two feasible approaches plus doing nothing when meaningful. Brownfield records actual behavior, constraints, affected users, compatibility, and rollback needs. Separate user evidence from model hypotheses. Make priority a reasoned judgment using user impact, confidence in evidence, effort, and dependencies without fabricated numeric precision. UI exploration is optional and routes to design-pm-workflow only when the slice changes an interface. Small work can use a single brief; no mandatory PRD/design/ticket duplication.
+
+### Interface contract
+
+The product brief is Markdown with stable sections: Audience and problem; Evidence and assumptions; Current behavior (brownfield); Options and trade-offs; Selected outcome; Scope and exclusions; Success evidence; Next slice; Unresolved decisions. Requirement IDs use RQ-001 style within the brief; one canonical brief owns those IDs. Output ends with proceed, investigate, or stop plus reasons, not an invented approval.
+
+### Dependency contract
+
+No feature dependency. Begin after the planning documentation is integrated.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- PS-01: exercise a request contains only a feature idea and the corresponding expected result in the formal spec.
+- PS-02: exercise an existing workflow is changed and the corresponding expected result in the formal spec.
+- PS-03: exercise evidence is insufficient and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-product-shaping-workflow.md).

--- a/openspec/changes/product-shaping-workflow/proposal.md
+++ b/openspec/changes/product-shaping-workflow/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M2.
+
+## What Changes
+
+- Author one greenfield task and one brownfield task with evidence, options, excluded scope, RQ IDs, and a correct next action. Include a misleading feature request and contradictory requirements.
+- Update the existing skills and PRD template using the examples; include exact output sections and decision rules. Follow skill-authoring guidance during implementation and retain upstream-provider routing.
+- Regenerate digest locks/client copies/templates; add packaging tests for assets and behavioral scenarios measuring decisions rather than just headings.
+
+## Capabilities
+
+### New Capabilities
+
+- `product-shaping-workflow`: Give agents concrete guidance and examples for choosing worthwhile product increments before writing specifications or code.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Modify agents/skills/discovery/SKILL.md
+- Modify agents/skills/prd-draft/SKILL.md
+- Modify agents/skills/review-inbox/SKILL.md
+- Modify agents/templates/prd.md
+- Create agents/templates/product-brief.md
+- Create agents/examples/product-shaping/greenfield.md and brownfield.md
+- Update agents/skills.lock.json and managed/generated copies
+- Modify docs/workflows/greenfield.md, brownfield.md and matching project templates
+- Test tests/test_templates.py and tests/test_rendering.py
+
+Dependencies: none.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-product-shaping-workflow.md).

--- a/openspec/changes/product-shaping-workflow/specs/product-shaping-workflow/spec.md
+++ b/openspec/changes/product-shaping-workflow/specs/product-shaping-workflow/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: PS-01 Evidence-based product shaping
+
+The workflow SHALL distinguish observed evidence, user decisions, and hypotheses; it SHALL compare feasible options and identify a bounded outcome before proposing implementation.
+
+#### Scenario: A request contains only a feature idea
+- **WHEN** a user asks for a dashboard without explaining the underlying problem
+- **THEN** the agent investigates audience and task evidence and records assumptions instead of treating the requested layout as validated product direction
+
+### Requirement: PS-02 Separate greenfield and brownfield entry paths
+
+Greenfield guidance SHALL shape the smallest useful outcome; brownfield guidance SHALL inspect existing behavior and preserve explicit compatibility boundaries.
+
+#### Scenario: An existing workflow is changed
+- **WHEN** a product already has users and integrations
+- **THEN** the brief identifies current behavior, affected consumers, migration/recovery needs, and a bounded change
+
+### Requirement: PS-03 Proportional handoff
+
+The workflow SHALL produce traceable outcome/requirement IDs and an explicit proceed, investigate, or stop decision; material unknowns SHALL remain visible and SHALL NOT become invented acceptance facts.
+
+#### Scenario: Evidence is insufficient
+- **WHEN** the value of a proposed feature remains uncertain
+- **THEN** the next slice is a bounded investigation with its evidence goal rather than an implementation commitment

--- a/openspec/changes/product-shaping-workflow/tasks.md
+++ b/openspec/changes/product-shaping-workflow/tasks.md
@@ -1,0 +1,24 @@
+## 1. Worked examples and review criteria
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Author one greenfield task and one brownfield task with evidence, options, excluded scope, RQ IDs, and a correct next action. Include a misleading feature request and contradictory requirements.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Skills and templates
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Update the existing skills and PRD template using the examples; include exact output sections and decision rules. Follow skill-authoring guidance during implementation and retain upstream-provider routing.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. Distribution and behavioral cases
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Regenerate digest locks/client copies/templates; add packaging tests for assets and behavioral scenarios measuring decisions rather than just headings.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-product-shaping-workflow.md).

--- a/openspec/changes/spec-delivery-traceability/design.md
+++ b/openspec/changes/spec-delivery-traceability/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.
+Read [product direction](../../../docs/product-direction.md) and the [delivery architecture](../../../docs/design/framework-delivery.md).
+
+## Goals / Non-Goals
+
+Goal: Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.
+
+Excluded: No automatic scope approval, duplicate spec store, spec-to-one-checkbox-ticket mapping, remote priority inference, or weakened finish gates.
+
+## Decisions
+
+New work records list dependency work IDs, requirement IDs, exact artifact references, and acceptance/verification text. Validate missing referenced local records, self-dependency, cycles, unsafe IDs, and absent local artifacts before publication. Dependency validation verifies graph integrity; it does not claim dependencies completed. work start checks dependency tracker state and fails explicitly on unfinished or unavailable dependencies; a terminal cancelled/duplicate item does not satisfy a completion dependency. Existing records with empty lists keep their current behavior. The native publish body includes scope, requirements, dependencies, artifacts, and acceptance plus the unchanged correlation marker. Re-publishing an already linked item remains idempotent and does not silently overwrite authored remote descriptions. Spec guidance creates one independently finishable OpenSpec change per behavior ticket; OpenSpec tasks are steps inside that ticket, not one ticket per checkbox. A shared parent epic has no completion gate over child specs.
+
+### Interface contract
+
+Add optional Work fields depends_on: list[str]=[] and requirements: list[str]=[]. Add validate_work_graph(records:dict[str,dict])->list[str] and render_ticket_body(work:dict)->str in traceability.py. Requirements are stable brief/spec requirement identifiers, not duplicated spec prose. Add ai-dlc work validate WORK_ID --root PATH (read-only, 0 valid/1 invalid). No automated interpretation of arbitrary natural-language specifications.
+
+### Dependency contract
+
+- product-shaping-workflow: consume its committed documented interfaces; do not implement an incompatible local substitute.
+
+## Risks / Trade-offs
+
+- Existing configuration or content is changed accidentally → retain compatibility and refusal-path tests.
+- An agent implements a neighboring ticket's responsibilities → use the explicit file/interface boundaries and dependency gate.
+- Generated assets drift from source → update source, integrity metadata and generated copies together and run required checks.
+
+## Migration Plan
+
+Use additive defaults for existing configurations. Preview before applicable mutations; preserve original files on validation failures. Deliver changes on an independently reviewed branch. Reverting owned assets must preserve authored project content and prior provider bindings.
+
+## Verification
+
+- TR-01: exercise a feature is decomposed and the corresponding expected result in the formal spec.
+- TR-02: exercise a ticket depends on itself and the corresponding expected result in the formal spec.
+- TR-03: exercise a published item is retried and the corresponding expected result in the formal spec.
+
+[Task-level instructions and acceptance example](../../../docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md).

--- a/openspec/changes/spec-delivery-traceability/proposal.md
+++ b/openspec/changes/spec-delivery-traceability/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.
+This implements the approved framework direction in [product direction](../../../docs/product-direction.md), milestone M2.
+
+## What Changes
+
+- Add missing ID, self/cycle, absent artifact, stable order, and rich body cases; preserve old-schema defaults and correlation values.
+- Validate before mutation, expose work validate, check dependency completion before branch/start effects, and render richer descriptions on first create only.
+- Update skill/template examples using PS requirement IDs; show an independently finishable change and a no-spec verification item; regenerate owned copies.
+
+## Capabilities
+
+### New Capabilities
+
+- `spec-delivery-traceability`: Give an executing agent an unambiguous connection from outcome to behavioral scenario, ticket, implementation step, and verification evidence.
+
+### Modified Capabilities
+
+None. Existing schema-4, content ownership, enrollment, and finish contracts remain unless an additive behavior is explicitly defined in this change.
+
+## Impact
+
+- Modify agents/skills/spec-from-prd/SKILL.md
+- Create agents/templates/delivery-slice.md
+- Modify src/ai_dlc/workflow.py
+- Modify src/ai_dlc/cli.py
+- Create src/ai_dlc/traceability.py
+- Test tests/test_traceability.py
+- Modify tests/test_workflow.py, tests/test_cli.py
+- Update docs/workflows/design-to-implementation.md and generated templates
+
+Dependencies: product-shaping-workflow.
+No implementation is complete. [Execution plan](../../../docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md).

--- a/openspec/changes/spec-delivery-traceability/specs/spec-delivery-traceability/spec.md
+++ b/openspec/changes/spec-delivery-traceability/specs/spec-delivery-traceability/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: TR-01 Explicit traceability
+
+New delivery guidance SHALL map product requirement IDs to formal behavioral scenarios when needed, a deliverable work item, and verification. Scope, rationale, spec, and task list SHALL retain distinct ownership.
+
+#### Scenario: A feature is decomposed
+- **WHEN** one outcome needs independently releasable behavior changes
+- **THEN** each ticket has explicit requirement references, dependencies, exclusions, and acceptance while each required OpenSpec change can finish independently
+
+### Requirement: TR-02 Valid dependency graph
+
+Work validation SHALL reject missing or cyclic dependencies and absent referenced artifacts before publication; start SHALL refuse incomplete or unavailable required dependency status.
+
+#### Scenario: A ticket depends on itself
+- **WHEN** the local dependency graph contains a cycle
+- **THEN** validation fails without creating or updating a tracker item
+
+### Requirement: TR-03 Compatible rich publication
+
+New issue publication SHALL include scope, references, dependencies, and acceptance while preserving existing correlation/idempotency and authored descriptions on repeat publication.
+
+#### Scenario: A published item is retried
+- **WHEN** the same work record already has a tracker binding
+- **THEN** publication reuses the existing issue and does not overwrite its authored description

--- a/openspec/changes/spec-delivery-traceability/tasks.md
+++ b/openspec/changes/spec-delivery-traceability/tasks.md
@@ -1,0 +1,24 @@
+## 1. Pure graph validation and ticket rendering
+
+- [ ] 1.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 1.2 Implement validate_work_graph and render_ticket_body with missing ID, self/cycle, stable order and rich body cases. Preserve correlation values. Task 2 owns optional Work fields, filesystem artifact checks and mutation ordering; the pure graph function does not inspect files or services.
+- [ ] 1.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 2. Workflow integration
+
+- [ ] 2.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 2.2 Validate before mutation, expose work validate, check dependency completion before branch/start effects, and render richer descriptions on first create only.
+- [ ] 2.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 3. Spec and task handoff guidance
+
+- [ ] 3.1 Define and run the focused acceptance/refusal cases in the execution plan.
+- [ ] 3.2 Update skill/template examples using PS requirement IDs; show an independently finishable change and a no-spec verification item; regenerate owned copies.
+- [ ] 3.3 Verify focused tests and inspect scope/compatibility before committing.
+
+## 4. Review and finish
+
+- [ ] 4.1 Run required project checks and strict OpenSpec validation.
+- [ ] 4.2 Complete source review, archive the delivered change, link PR/CI evidence, and finish through the configured workflow.
+
+[Detailed plan](../../../docs/superpowers/plans/2026-09-05-spec-delivery-traceability.md).

--- a/project-templates/project/docs/development-workflow.md.jinja
+++ b/project-templates/project/docs/development-workflow.md.jinja
@@ -5,6 +5,15 @@ stages; the [tool map](workflows/tool-map.md) shows which configured provider or
 service currently performs each role. The CLI owns lifecycle mutation; MCP
 exposes only its reviewed work, doctor, and knowledge services.
 
+The selected harness can use installed tools directly. AI-DLC equips it with
+environment setup, project structure, guidance, and integration; the services own
+specific validation and completion boundaries. UI/UX is an optional workflow
+within product development, alongside other design and verification methods.
+
+Requirements explain outcomes; formal specifications define behavior; tickets
+organize deliverable slices; tasks describe implementation steps. Keep references
+between these artifacts instead of duplicating their contents.
+
 - [Greenfield development](workflows/greenfield.md)
 - [Brownfield development](workflows/brownfield.md)
 - [Design to implementation](workflows/design-to-implementation.md)

--- a/project-templates/project/docs/workflows/design-to-implementation.md
+++ b/project-templates/project/docs/workflows/design-to-implementation.md
@@ -5,6 +5,11 @@ decisions. It links to requirements and formal specifications without copying
 them. Implementation is ready when the following evidence is present or
 explicitly judged unnecessary.
 
+Begin with evidence, assumptions, alternatives, and a shaped product outcome.
+New products need a smallest useful slice; existing products need observed behavior
+and compatibility boundaries. Apply UI/UX exploration only where relevant and
+scale documentation and evaluation to the change's scope and risk.
+
 [Back to the workflow map](../development-workflow.md)
 
 | Area | Evidence |


### PR DESCRIPTION
## Outcome

Make AI-DLC's portable, replaceable framework direction executable without relying on this conversation. UI/UX remains an optional workflow within broader greenfield and brownfield product development.

## Changes

- Revise the README, workflow handbooks and project templates; distinguish existing v4 behavior, planned capabilities and outstanding release evidence.
- Add product direction, delivery architecture, dependency-ordered roadmap, and an executor handoff.
- Provide ten scoped delivery plans with interfaces, files, task steps, requirement coverage, examples, refusal cases, checks, exclusions and completion rules.
- Add seven independently finishable OpenSpec changes and three verification plans; preserve the existing v4 change and its unfinished gates.
- Bind eight new and two existing sandbox delivery tickets, verify fourteen native blocking edges, and retain non-secret project-specific Linear mappings.

Planning ticket: https://linear.app/sandbox-aidlc/issue/SAN-8/document-and-sequence-the-portable-framework-delivery-roadmap

## Validation

- Source bootstrap completed.
- All five required project checks passed; 785 tests passed.
- Strict OpenSpec validation: 9 passed, 0 failed.
- Work-record, local-reference, requirement-coverage and acyclic-dependency audits passed.
- Linear read-back verified ten matching Backlog tickets and all fourteen directed blocking relations.
- Staged files checked for the configured token and ignored local-secret paths.

The local required-check receipt records a dirty planning tree on baseline 241e715; it is not merged-revision CI evidence. Details: docs/planning/framework-delivery-review.md.

## Scope and review

No planned runtime command, component schema, skill or evaluation result is implemented by this PR. No delivery ticket is marked Done. This PR completes planning only after review/merge/CI; implementation starts with SAN-9, or independently SAN-13 for product guidance.
